### PR TITLE
Fix checkout issue of CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,8 +29,6 @@ jobs:
         steps:
             - name: Checkout project
               uses: actions/checkout@v4
-              with:
-                  ref: "${{ github.event.pull_request.merge_commit_sha }}"
 
             - name: Start Docker services
               if: ${{ inputs.docker }}


### PR DESCRIPTION
The checkout via:

```
                  ref: "${{ github.event.pull_request.merge_commit_sha }}"
```

is flacky and can end in checking out a old commit.