### PR TITLE
Refactor chat request handler to middleware-based architecture

### DIFF
--- a/integrations/symfony/config/chat_request_handler.php
+++ b/integrations/symfony/config/chat_request_handler.php
@@ -16,6 +16,9 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 use ModelflowAi\Chat\AIChatRequestHandler;
 use ModelflowAi\Chat\AIChatRequestHandlerInterface;
 use ModelflowAi\Chat\ChatPackage;
+use ModelflowAi\Chat\Middleware\Adapter\AdapterDecisionMiddleware;
+use ModelflowAi\Chat\Middleware\Adapter\AdapterExecutionMiddleware;
+use ModelflowAi\Chat\Middleware\ResponseFormat\ResponseFormatMiddleware;
 use ModelflowAi\Chat\Middleware\Tools\ToolExecutionMiddleware;
 use ModelflowAi\Chat\ToolInfo\ToolExecutor;
 use ModelflowAi\Chat\ToolInfo\ToolExecutorInterface;
@@ -41,6 +44,17 @@ return static function (ContainerConfigurator $container) {
         ->alias(ToolExecutorInterface::class, 'modelflow_ai.chat.tool_executor');
 
     $container->services()
+        ->set('modelflow_ai.chat.middleware.adapter_decision', AdapterDecisionMiddleware::class)
+        ->args([
+            service('modelflow_ai.chat_request_handler.decision_tree'),
+        ])
+        ->tag('modelflow_ai.chat.middleware', ['priority' => PHP_INT_MAX - 10]);
+
+    $container->services()
+        ->set('modelflow_ai.chat.middleware.response_format', ResponseFormatMiddleware::class)
+        ->tag('modelflow_ai.chat.middleware');
+
+    $container->services()
         ->set('modelflow_ai.chat.middleware.tool_execution', ToolExecutionMiddleware::class)
         ->args([
             service('modelflow_ai.chat.tool_executor'),
@@ -49,9 +63,12 @@ return static function (ContainerConfigurator $container) {
         ->tag('modelflow_ai.chat.middleware');
 
     $container->services()
+        ->set('modelflow_ai.chat.middleware.adapter_execution', AdapterExecutionMiddleware::class)
+        ->tag('modelflow_ai.chat.middleware', ['priority' => PHP_INT_MIN + 10]);
+
+    $container->services()
         ->set('modelflow_ai.chat_request_handler', AIChatRequestHandler::class)
         ->args([
-            service('modelflow_ai.chat_request_handler.decision_tree'),
             tagged_iterator('modelflow_ai.chat.middleware'),
         ])
         ->alias(AIChatRequestHandlerInterface::class, 'modelflow_ai.chat_request_handler');

--- a/packages/chat/src/AIChatRequestHandler.php
+++ b/packages/chat/src/AIChatRequestHandler.php
@@ -30,26 +30,33 @@ use Webmozart\Assert\Assert;
 
 final class AIChatRequestHandler implements AIChatRequestHandlerInterface
 {
+    public static function create(
+        DecisionTreeInterface $decisionTree,
+        iterable $middleware = [],
+    ): self {
+        $middleware = [
+            new AdapterDecisionMiddleware($decisionTree),
+            new ResponseFormatMiddleware(),
+            ...$middleware,
+            new AdapterExecutionMiddleware(),
+        ];
+
+        return new self($middleware);
+    }
+
     private readonly AIChatMiddlewareStack $middlewareStack;
 
     /**
-     * @param DecisionTreeInterface<AIChatRequest, AIChatAdapterInterface> $decisionTree
      * @param AIChatMiddlewareInterface[] $middleware Optional middleware to add
      */
     public function __construct(
-        DecisionTreeInterface $decisionTree,
         iterable $middleware = [],
     ) {
         $this->middlewareStack = new AIChatMiddlewareStack();
 
-        $this->middlewareStack->add(new AdapterDecisionMiddleware($decisionTree));
-        $this->middlewareStack->add(new ResponseFormatMiddleware());
-
         foreach ($middleware as $m) {
             $this->middlewareStack->add($m);
         }
-
-        $this->middlewareStack->add(new AdapterExecutionMiddleware());
     }
 
     public function createRequest(AIChatMessage ...$messages): AIChatRequestBuilder

--- a/packages/chat/src/Request/AIChatRequest.php
+++ b/packages/chat/src/Request/AIChatRequest.php
@@ -51,7 +51,7 @@ class AIChatRequest implements CriteriaBehaviour
         private readonly array $toolInfos,
         private array $options,
         callable $requestHandler,
-        private readonly array $metadata = [],
+        private array $metadata = [],
         private readonly ?ResponseFormatInterface $responseFormat = null,
         private readonly ToolChoiceEnum $toolChoice = ToolChoiceEnum::AUTO,
     ) {
@@ -170,6 +170,14 @@ class AIChatRequest implements CriteriaBehaviour
     {
         $clone = clone $this;
         $clone->messages = new AIChatMessageCollection(...[...$this->messages, $message]);
+
+        return $clone;
+    }
+
+    public function withMetadata(array $metadata): static
+    {
+        $clone = clone $this;
+        $clone->metadata = $metadata;
 
         return $clone;
     }


### PR DESCRIPTION
- Extract adapter decision/execution logic into dedicated middleware
- Add ResponseFormatMiddleware for better separation of concerns
- Introduce static factory method for easier handler instantiation
- Make AIChatRequest metadata mutable via withMetadata() method
- Configure middleware priority order in Symfony integration
- Simplify AIChatRequestHandler constructor by removing DecisionTree dependency