### PR TITLE
Add custom embeddings factory support for Symfony integration

### DIFF
--- a/docs/integration/symfony.md
+++ b/docs/integration/symfony.md
@@ -58,6 +58,32 @@ modelflow_ai:
                 dsn: 'qdrant://localhost:6333/documents'
 ```
 
+### Custom Providers
+```yaml
+modelflow_ai:
+    providers:
+        custom:
+            my_custom_provider:
+                chat_factory: 'App\Service\CustomChatFactory'
+                completion_factory: 'App\Service\CustomCompletionFactory'
+                image_factory: 'App\Service\CustomImageFactory'
+                embeddings_factory: 'App\Service\CustomEmbeddingsFactory'
+
+    adapters:
+        my_custom_model:
+            enabled: true
+            provider: 'my_custom_provider'
+            model: 'custom-model-1'
+            chat: true
+
+    embeddings:
+        generators:
+            custom_embeddings:
+                enabled: true
+                provider: 'my_custom_provider'
+                model: 'custom-embedding-model'
+```
+
 ## Usage in Controllers
 
 ### Dependency Injection

--- a/integrations/symfony/phpstan.neon
+++ b/integrations/symfony/phpstan.neon
@@ -7,3 +7,6 @@ parameters:
     excludePaths:
         - vendor/*
         - var/*
+    bootstrapFiles:
+        - tests/phpstan-bootstrap.php
+    checkGenericClassInNonGenericObjectType: false

--- a/integrations/symfony/src/Configuration/BundleConfiguration.php
+++ b/integrations/symfony/src/Configuration/BundleConfiguration.php
@@ -178,7 +178,7 @@ final class BundleConfiguration
     {
         $node = new ArrayNodeDefinition('custom');
 
-        // @phpstan-ignore-next-line
+        /** @phpstan-ignore-next-line */
         $node->arrayPrototype()
             ->children()
                 ->scalarNode('chat_factory')->end()
@@ -195,7 +195,7 @@ final class BundleConfiguration
     {
         $node = new ArrayNodeDefinition('adapters');
 
-        // @phpstan-ignore-next-line
+        /** @phpstan-ignore-next-line */
         $node->defaultValue([])
             ->info('You can configure your own adapter here or use a preconfigured one (see examples) and enable it.')
             ->example(DefaultConfigurationProvider::getDefaultValues())
@@ -257,7 +257,7 @@ final class BundleConfiguration
     {
         $node = new ArrayNodeDefinition('embeddings');
 
-        // @phpstan-ignore-next-line
+        /** @phpstan-ignore-next-line */
         $node->children()
             ->arrayNode('generators')
                 ->defaultValue([])
@@ -324,7 +324,7 @@ final class BundleConfiguration
     {
         $node = new ArrayNodeDefinition('experts');
 
-        // @phpstan-ignore-next-line
+        /** @phpstan-ignore-next-line */
         $node->defaultValue([])
             ->info('You can configure your experts here.')
             ->arrayPrototype()

--- a/integrations/symfony/src/Configuration/BundleConfiguration.php
+++ b/integrations/symfony/src/Configuration/BundleConfiguration.php
@@ -184,6 +184,7 @@ final class BundleConfiguration
                 ->scalarNode('chat_factory')->end()
                 ->scalarNode('completion_factory')->end()
                 ->scalarNode('image_factory')->end()
+                ->scalarNode('embeddings_factory')->end()
                 ->append($this->createCriteriaNode([]))
             ->end();
 

--- a/integrations/symfony/src/Configuration/BundleConfiguration.php
+++ b/integrations/symfony/src/Configuration/BundleConfiguration.php
@@ -57,7 +57,6 @@ final class BundleConfiguration
     {
         $node = new ArrayNodeDefinition('openai');
 
-        // @phpstan-ignore-next-line
         $node->children()
             ->booleanNode('enabled')->defaultFalse()->end()
             ->arrayNode('credentials')
@@ -76,7 +75,6 @@ final class BundleConfiguration
     {
         $node = new ArrayNodeDefinition('mistral');
 
-        // @phpstan-ignore-next-line
         $node->children()
             ->booleanNode('enabled')->defaultFalse()->end()
             ->arrayNode('credentials')
@@ -95,7 +93,6 @@ final class BundleConfiguration
     {
         $node = new ArrayNodeDefinition('anthropic');
 
-        // @phpstan-ignore-next-line
         $node->children()
             ->booleanNode('enabled')->defaultFalse()->end()
             ->arrayNode('credentials')
@@ -115,7 +112,6 @@ final class BundleConfiguration
     {
         $node = new ArrayNodeDefinition('fireworksai');
 
-        // @phpstan-ignore-next-line
         $node->children()
             ->booleanNode('enabled')->defaultFalse()->end()
             ->arrayNode('credentials')
@@ -135,7 +131,6 @@ final class BundleConfiguration
     {
         $node = new ArrayNodeDefinition('google_gemini');
 
-        // @phpstan-ignore-next-line
         $node->children()
             ->booleanNode('enabled')->defaultFalse()->end()
             ->arrayNode('credentials')
@@ -154,7 +149,6 @@ final class BundleConfiguration
     {
         $node = new ArrayNodeDefinition('ollama');
 
-        // @phpstan-ignore-next-line
         $node->children()
             ->booleanNode('enabled')->defaultFalse()->end()
             ->scalarNode('url')
@@ -178,7 +172,6 @@ final class BundleConfiguration
     {
         $node = new ArrayNodeDefinition('custom');
 
-        /** @phpstan-ignore-next-line */
         $node->arrayPrototype()
             ->children()
                 ->scalarNode('chat_factory')->end()
@@ -195,7 +188,6 @@ final class BundleConfiguration
     {
         $node = new ArrayNodeDefinition('adapters');
 
-        /** @phpstan-ignore-next-line */
         $node->defaultValue([])
             ->info('You can configure your own adapter here or use a preconfigured one (see examples) and enable it.')
             ->example(DefaultConfigurationProvider::getDefaultValues())
@@ -257,7 +249,6 @@ final class BundleConfiguration
     {
         $node = new ArrayNodeDefinition('embeddings');
 
-        /** @phpstan-ignore-next-line */
         $node->children()
             ->arrayNode('generators')
                 ->defaultValue([])
@@ -324,7 +315,6 @@ final class BundleConfiguration
     {
         $node = new ArrayNodeDefinition('experts');
 
-        /** @phpstan-ignore-next-line */
         $node->defaultValue([])
             ->info('You can configure your experts here.')
             ->arrayPrototype()

--- a/integrations/symfony/src/DependencyInjection/EmbeddingsLoader.php
+++ b/integrations/symfony/src/DependencyInjection/EmbeddingsLoader.php
@@ -36,6 +36,7 @@ use Symfony\Component\DependencyInjection\Reference;
  * @phpstan-import-type EmbeddingGeneratorConfigType from ModelflowAiBundle
  * @phpstan-import-type EmbeddingStoreConfigType from ModelflowAiBundle
  * @phpstan-import-type EmbeddingRequestHandlerConfigType from ModelflowAiBundle
+ * @phpstan-import-type CustomProviderConfigType from ModelflowAiBundle
  */
 final class EmbeddingsLoader
 {
@@ -49,8 +50,12 @@ final class EmbeddingsLoader
      */
     private array $defaultStoreSet = [];
 
+    /**
+     * @param array<string, CustomProviderConfigType> $customProviders
+     */
     public function __construct(
         private readonly ContainerConfigurator $container,
+        private readonly array $customProviders = [],
     ) {
         // Check if embeddings package is installed
         if (!\class_exists(EmbeddingsPackage::class)) {
@@ -69,12 +74,15 @@ final class EmbeddingsLoader
         $prefix = 'modelflow_ai.embeddings.' . $key;
         $adapterId = $prefix . '.adapter';
 
+        // Get the factory service ID - check for custom factory first
+        $factoryServiceId = $this->getEmbeddingFactoryServiceId($embedding['provider']);
+
         // Configure the embedding adapter
         $this->container->services()
             ->set($adapterId, EmbeddingAdapterInterface::class)
             ->factory(
                 [
-                    new Reference('modelflow_ai.providers.' . $embedding['provider'] . '.embedding_adapter_factory'),
+                    new Reference($factoryServiceId),
                     'createEmbeddingAdapter',
                 ],
             )
@@ -212,5 +220,15 @@ final class EmbeddingsLoader
         // Create alias for the request handler
         $this->container->services()
             ->alias(EmbeddingsRequestHandlerInterface::class, 'modelflow_ai.embeddings.request_handler');
+    }
+
+    /**
+     * Get the factory service ID for embedding adapter.
+     * Checks for custom factory first, falls back to default provider factory.
+     */
+    private function getEmbeddingFactoryServiceId(string $provider): string
+    {
+        // Fall back to default provider factory
+        return $this->customProviders[$provider]['embeddings_factory'] ?? \sprintf('modelflow_ai.providers.%s.embedding_adapter_factory', $provider);
     }
 }

--- a/integrations/symfony/src/ModelflowAiBundle.php
+++ b/integrations/symfony/src/ModelflowAiBundle.php
@@ -77,6 +77,7 @@ use Symfony\Component\HttpKernel\KernelInterface;
  *      chat_factory?: string,
  *      completion_factory?: string,
  *      image_factory?: string,
+ *      embeddings_factory?: string,
  *      criteria: CriteriaInterface[]
  *  }
  * @phpstan-type ProvidersConfigType array{
@@ -247,7 +248,7 @@ class ModelflowAiBundle extends AbstractBundle
         $this->setupChatAdapters($container, $adaptersConfig, $providersConfig);
         $this->setupCompletionAdapters($container, $adaptersConfig, $providersConfig);
         $this->setupImageAdapters($container, $adaptersConfig, $providersConfig);
-        $this->setupEmbeddings($container, $embeddingsConfig);
+        $this->setupEmbeddings($container, $embeddingsConfig, $providersConfig);
         $this->setupExperts($container, $expertsConfig);
     }
 
@@ -368,8 +369,13 @@ class ModelflowAiBundle extends AbstractBundle
 
         // Add embedding config files
         foreach ($embeddingsConfig['generators'] ?? [] as $generator) {
-            $configFiles[] = $generator['provider'] . '/common.php';
-            $configFiles[] = $generator['provider'] . '/embeddings.php';
+            $provider = $generator['provider'];
+            if (\array_key_exists($provider, $providersConfig['customProviders'])) {
+                continue;
+            }
+
+            $configFiles[] = $provider . '/common.php';
+            $configFiles[] = $provider . '/embeddings.php';
         }
 
         return $configFiles;
@@ -467,8 +473,9 @@ class ModelflowAiBundle extends AbstractBundle
 
     /**
      * @param ExtractedEmbeddingsConfigType $embeddingsConfig
+     * @param ExtractedProvidersConfigType $providersConfig
      */
-    private function setupEmbeddings(ContainerConfigurator $container, array $embeddingsConfig): void
+    private function setupEmbeddings(ContainerConfigurator $container, array $embeddingsConfig, array $providersConfig): void
     {
         $generators = $embeddingsConfig['generators'] ?? [];
         $stores = $embeddingsConfig['stores'] ?? [];
@@ -480,7 +487,7 @@ class ModelflowAiBundle extends AbstractBundle
             return;
         }
 
-        $embeddingsLoader = new EmbeddingsLoader($container);
+        $embeddingsLoader = new EmbeddingsLoader($container, $providersConfig['customProviders']);
 
         // Load generators first
         $hasEnabledGenerator = false;

--- a/integrations/symfony/tests/Resources/10_custom_adapters.md
+++ b/integrations/symfony/tests/Resources/10_custom_adapters.md
@@ -10,6 +10,7 @@ modelflow_ai:
                 chat_factory: "app.my_custom_chat_factory"
                 completion_factory: "app.my_custom_completion_factory"
                 image_factory: "app.my_custom_image_factory"
+                embeddings_factory: "app.my_custom_embeddings_factory"
 
     adapters:
         my_custom_model:

--- a/integrations/symfony/tests/phpstan-bootstrap.php
+++ b/integrations/symfony/tests/phpstan-bootstrap.php
@@ -11,6 +11,24 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
+/**
+ * PHPStan Bootstrap File - Symfony DI Helper Function Stubs.
+ *
+ * This file provides fallback definitions for Symfony's Dependency Injection
+ * configurator helper functions used in service configuration files (config/*.php).
+ *
+ * PHPStan performs static analysis without executing code, so it cannot discover
+ * these helper functions that are only available at runtime within Symfony's
+ * ContainerConfigurator context. This bootstrap file defines stub implementations
+ * that allow PHPStan to properly analyze service configuration files.
+ *
+ * The function_exists() guards ensure these stubs don't conflict with Symfony's
+ * actual implementations when the code is executed at runtime.
+ *
+ * @internal this file is only used during static analysis and should not be
+ *           included in production code
+ */
+
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
@@ -44,5 +62,15 @@ if (!\function_exists('Symfony\Component\DependencyInjection\Loader\Configurator
     function service_closure(string $serviceId): ServiceClosureArgument
     {
         return new ServiceClosureArgument(new Reference($serviceId));
+    }
+}
+
+if (!\function_exists('Symfony\Component\DependencyInjection\Loader\Configurator\param')) {
+    /**
+     * Creates a parameter reference.
+     */
+    function param(string $name): string
+    {
+        return '%' . $name . '%';
     }
 }

--- a/integrations/symfony/tests/phpstan-bootstrap.php
+++ b/integrations/symfony/tests/phpstan-bootstrap.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Modelflow AI package.
+ *
+ * (c) Johannes Wachter <johannes@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
+use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
+use Symfony\Component\DependencyInjection\Reference;
+
+if (!\function_exists('Symfony\Component\DependencyInjection\Loader\Configurator\service')) {
+    /**
+     * Creates a service reference.
+     */
+    function service(string $serviceId): Reference
+    {
+        return new Reference($serviceId);
+    }
+}
+
+if (!\function_exists('Symfony\Component\DependencyInjection\Loader\Configurator\tagged_iterator')) {
+    /**
+     * Creates a tagged iterator argument.
+     */
+    function tagged_iterator(string $tag): TaggedIteratorArgument
+    {
+        return new TaggedIteratorArgument($tag);
+    }
+}
+
+if (!\function_exists('Symfony\Component\DependencyInjection\Loader\Configurator\service_closure')) {
+    /**
+     * Creates a service closure argument.
+     */
+    function service_closure(string $serviceId): ServiceClosureArgument
+    {
+        return new ServiceClosureArgument(new Reference($serviceId));
+    }
+}


### PR DESCRIPTION
- Add embeddings_factory configuration option to custom providers
- Update EmbeddingsLoader to use custom factory when configured
- Pass custom providers config to EmbeddingsLoader
- Skip loading provider config files for custom providers in embeddings
- Add documentation and test examples for custom embeddings factory

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Symfony integration now supports custom embedding provider factories; a new embeddings_factory option can be defined and referenced in provider and embedding-generator configurations.

* **Documentation**
  * Added Symfony docs and example configs showing how to declare and reference custom providers, adapters, and embedding generators.
  * Updated example test resources and static-analysis helpers to support these docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->