### PR TITLE
Update Gemini adapter examples to use gemini-2.5-pro

### DIFF
--- a/packages/google-gemini-adapter/examples/bootstrap.php
+++ b/packages/google-gemini-adapter/examples/bootstrap.php
@@ -44,7 +44,7 @@ $googleGeminiClient = \Gemini::factory()
     ->withStreamHandler(fn (RequestInterface $request): ResponseInterface => $client->sendRequest($request))
     ->make();
 
-$flashAdapter = new GoogleGeminiChatAdapter($googleGeminiClient, 'models/gemini-2.0-flash');
+$flashAdapter = new GoogleGeminiChatAdapter($googleGeminiClient, 'models/gemini-2.5-pro');
 
 $adapters[] = new DecisionRule($flashAdapter, [FeatureCriteria::STREAM, FeatureCriteria::IMAGE_TO_TEXT]);
 

--- a/packages/google-gemini-adapter/examples/list-models.php
+++ b/packages/google-gemini-adapter/examples/list-models.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Modelflow AI package.
+ *
+ * (c) Johannes Wachter <johannes@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use Http\Discovery\Psr18ClientDiscovery;
+use Symfony\Component\Dotenv\Dotenv;
+
+(new Dotenv())->bootEnv(__DIR__ . '/.env');
+
+$apiKey = $_ENV['GOOGLE_GEMINI_API_KEY'];
+if (!$apiKey) {
+    throw new \RuntimeException('Google Gemini API key is required');
+}
+
+$client = Psr18ClientDiscovery::find();
+
+$url = "https://generativelanguage.googleapis.com/v1/models?key={$apiKey}";
+
+$request = new \Nyholm\Psr7\Request('GET', $url);
+$response = $client->sendRequest($request);
+
+$body = (string) $response->getBody();
+$data = \json_decode($body, true, 512, \JSON_THROW_ON_ERROR);
+
+echo "Available Gemini models that support generateContent:\n\n";
+if (isset($data['models'])) {
+    foreach ($data['models'] as $model) {
+        $name = $model['name'] ?? 'unknown';
+        $displayName = $model['displayName'] ?? 'N/A';
+        $description = $model['description'] ?? 'N/A';
+
+        $methods = $model['supportedGenerationMethods'] ?? [];
+        if (\in_array('generateContent', $methods, true)) {
+            echo "✓ {$name}\n";
+            echo "  Display: {$displayName}\n";
+            echo "  Description: {$description}\n";
+            echo "  Methods: " . \implode(', ', $methods) . "\n\n";
+        }
+    }
+} else {
+    echo "Error: " . \print_r($data, true) . "\n";
+}


### PR DESCRIPTION
- Update bootstrap.php to use models/gemini-2.5-pro instead of models/gemini-2.0-flash
- Add list-models.php utility script to query available Gemini models from the API
- Use latest stable Pro model (Gemini 2.5 Pro, released June 2025)
- Gemini 3 Pro not yet available through standard API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new example demonstrating retrieval and display of available Google Gemini models with their capabilities and supported generation methods.

* **Chores**
  * Updated Google Gemini model to the latest available version in example configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->