### PR TITLE
Add support for metadata-only tools without requiring instances

### DIFF
--- a/packages/chat/src/Middleware/Tools/ToolResponseDecorator.php
+++ b/packages/chat/src/Middleware/Tools/ToolResponseDecorator.php
@@ -71,6 +71,10 @@ final class ToolResponseDecorator implements AIChatResponseInterface
 
             // Execute each tool and add the tool response messages
             foreach ($toolCalls as $toolCall) {
+                if (!\array_key_exists($toolCall->name, $request->getTools())) {
+                    continue;
+                }
+
                 $toolResponseMessage = $this->toolExecutor->execute($request, $toolCall);
                 $request = $request->withMessage($toolResponseMessage);
             }

--- a/packages/chat/src/Middleware/Tools/ToolStreamResponseDecorator.php
+++ b/packages/chat/src/Middleware/Tools/ToolStreamResponseDecorator.php
@@ -60,6 +60,10 @@ final class ToolStreamResponseDecorator implements AIChatResponseStreamInterface
             // Collect tool calls if present
             if (null !== $message->toolCalls && \count($message->toolCalls) > 0) {
                 foreach ($message->toolCalls as $toolCall) {
+                    if (!\array_key_exists($toolCall->name, $this->request->getTools())) {
+                        continue;
+                    }
+
                     $toolCalls[] = $toolCall;
                 }
             }

--- a/packages/chat/src/Request/Builder/AIChatRequestBuilder.php
+++ b/packages/chat/src/Request/Builder/AIChatRequestBuilder.php
@@ -68,6 +68,11 @@ class AIChatRequestBuilder
     protected array $tools = [];
 
     /**
+     * @var ToolInfo[]
+     */
+    protected array $toolInfos = [];
+
+    /**
      * @var array<string, mixed>
      */
     protected array $metadata = [];
@@ -203,7 +208,36 @@ class AIChatRequestBuilder
 
     public function tool(string $name, object $instance, ?string $method = null): static
     {
+        foreach ($this->toolInfos as $toolInfo) {
+            if ($toolInfo->name === $name) {
+                throw new \InvalidArgumentException(
+                    \sprintf('Tool with name "%s" already exists as direct ToolInfo', $name),
+                );
+            }
+        }
+
         $this->tools[$name] = [$instance, $method ?? $name];
+
+        return $this;
+    }
+
+    public function addToolInfo(ToolInfo $toolInfo): static
+    {
+        if (isset($this->tools[$toolInfo->name])) {
+            throw new \InvalidArgumentException(
+                \sprintf('Tool with name "%s" already exists as executable tool', $toolInfo->name),
+            );
+        }
+
+        foreach ($this->toolInfos as $existing) {
+            if ($existing->name === $toolInfo->name) {
+                throw new \InvalidArgumentException(
+                    \sprintf('Tool with name "%s" already exists as direct ToolInfo', $toolInfo->name),
+                );
+            }
+        }
+
+        $this->toolInfos[] = $toolInfo;
 
         return $this;
     }
@@ -213,11 +247,13 @@ class AIChatRequestBuilder
      */
     protected function buildToolInfos(): array
     {
-        return \array_map(
+        $reflectionToolInfos = \array_map(
             fn (string $name, array $tool) => ToolInfoBuilder::buildToolInfo($tool[0], $tool[1], $name),
             \array_keys($this->tools),
             $this->tools,
         );
+
+        return \array_merge($reflectionToolInfos, $this->toolInfos);
     }
 
     /**

--- a/packages/chat/tests/Unit/Middleware/Tools/ToolResponseDecoratorTest.php
+++ b/packages/chat/tests/Unit/Middleware/Tools/ToolResponseDecoratorTest.php
@@ -62,6 +62,7 @@ class ToolResponseDecoratorTest extends TestCase
         $this->toolExecutor = $this->prophesize(ToolExecutor::class);
 
         $this->request->getMetadata()->willReturn(['key' => 'value']);
+        $this->request->getTools()->willReturn([]);
 
         $this->nextMiddleware = function ($request, $adapter) {
             return new AIChatResponse(
@@ -216,9 +217,13 @@ class ToolResponseDecoratorTest extends TestCase
             new Usage(5, 10, 15),
         );
 
+        // Mock getTools() to include the tool
+        $this->request->getTools()->willReturn(['tool_name' => [(object) [], 'method']]);
+
         // Mock the request handling
         $updatedRequest = $this->prophesize(AIChatRequest::class);
         $updatedRequest->getMetadata()->willReturn(['key' => 'updated']);
+        $updatedRequest->getTools()->willReturn(['tool_name' => [(object) [], 'method']]);
 
         $this->request->withMessage(Argument::type(AIChatMessage::class))
             ->willReturn($updatedRequest->reveal());
@@ -272,6 +277,12 @@ class ToolResponseDecoratorTest extends TestCase
 
     public function testProcessToolCallsWithMultipleToolCalls(): void
     {
+        // Mock getTools() to include both tools
+        $this->request->getTools()->willReturn([
+            'tool_name_1' => [(object) [], 'method1'],
+            'tool_name_2' => [(object) [], 'method2'],
+        ]);
+
         // Create multiple tool calls
         $toolCall1 = new AIChatToolCall(
             ToolTypeEnum::FUNCTION,
@@ -295,6 +306,10 @@ class ToolResponseDecoratorTest extends TestCase
 
         // Mock the request handling
         $updatedRequest = $this->prophesize(AIChatRequest::class);
+        $updatedRequest->getTools()->willReturn([
+            'tool_name_1' => [(object) [], 'method1'],
+            'tool_name_2' => [(object) [], 'method2'],
+        ]);
         $this->request->withMessage(Argument::type(AIChatMessage::class))
             ->willReturn($updatedRequest->reveal());
 
@@ -313,6 +328,10 @@ class ToolResponseDecoratorTest extends TestCase
             ->willReturn($toolResponseMessage1);
 
         $updatedRequest2 = $this->prophesize(AIChatRequest::class);
+        $updatedRequest2->getTools()->willReturn([
+            'tool_name_1' => [(object) [], 'method1'],
+            'tool_name_2' => [(object) [], 'method2'],
+        ]);
         $updatedRequest->withMessage($toolResponseMessage1)->willReturn($updatedRequest2->reveal());
 
         $this->toolExecutor->execute(Argument::type(AIChatRequest::class), $toolCall2)
@@ -360,6 +379,9 @@ class ToolResponseDecoratorTest extends TestCase
 
     public function testProcessToolCallsRespectsMaxExecutions(): void
     {
+        // Mock getTools() to include the tool
+        $this->request->getTools()->willReturn(['recursive_tool' => [(object) [], 'method']]);
+
         // Create a response chain with tool calls that would exceed max executions
         $toolCall = new AIChatToolCall(
             ToolTypeEnum::FUNCTION,
@@ -377,6 +399,7 @@ class ToolResponseDecoratorTest extends TestCase
 
         // Mock the request handling for first call
         $updatedRequest = $this->prophesize(AIChatRequest::class);
+        $updatedRequest->getTools()->willReturn(['recursive_tool' => [(object) [], 'method']]);
         $this->request->withMessage(Argument::type(AIChatMessage::class))
             ->willReturn($updatedRequest->reveal());
 
@@ -391,6 +414,7 @@ class ToolResponseDecoratorTest extends TestCase
 
         $finalRequest = $this->prophesize(AIChatRequest::class);
         $finalRequest->getMetadata()->willReturn(['key' => 'final']);
+        $finalRequest->getTools()->willReturn(['recursive_tool' => [(object) [], 'method']]);
         $updatedRequest->withMessage($toolResponseMessage)->willReturn($finalRequest->reveal());
         $finalRequest->withMessage(Argument::any())->willReturn($finalRequest->reveal());
 
@@ -457,5 +481,87 @@ class ToolResponseDecoratorTest extends TestCase
 
         // Check the accumulated usage (1,2,3 + 5,10,15 + 2,3,4 + 1,1,1)
         $this->assertSame(23, $result->getUsage()?->totalTokens);
+    }
+
+    public function testProcessToolCallsSkipsMetadataOnlyTools(): void
+    {
+        // Create a tool call for a metadata-only tool
+        $metadataToolCall = new AIChatToolCall(
+            ToolTypeEnum::FUNCTION,
+            'id_456',
+            'metadata_only_tool',
+            ['query' => 'test'],
+        );
+
+        // Create a tool call for an executable tool
+        $executableToolCall = new AIChatToolCall(
+            ToolTypeEnum::FUNCTION,
+            'id_123',
+            'executable_tool',
+            ['param' => 'value'],
+        );
+
+        $response = new AIChatResponse(
+            $this->request->reveal(),
+            new AIChatResponseMessage(AIChatMessageRoleEnum::ASSISTANT, 'Hello', [$metadataToolCall, $executableToolCall]),
+            new Usage(5, 10, 15),
+        );
+
+        // Mock getTools() to only return the executable tool
+        $this->request->getTools()->willReturn([
+            'executable_tool' => [(object) [], 'method'],
+        ]);
+
+        // Mock the request handling
+        $updatedRequest = $this->prophesize(AIChatRequest::class);
+        $updatedRequest->getMetadata()->willReturn(['key' => 'updated']);
+        $updatedRequest->getTools()->willReturn([
+            'executable_tool' => [(object) [], 'method'],
+        ]);
+
+        $this->request->withMessage(Argument::type(AIChatMessage::class))
+            ->willReturn($updatedRequest->reveal());
+
+        // Mock the tool executor - should ONLY be called for executable tool
+        $toolResponseMessage = new AIChatMessage(
+            AIChatMessageRoleEnum::TOOL,
+            'Tool response',
+        );
+        $this->toolExecutor->execute(Argument::type(AIChatRequest::class), $executableToolCall)
+            ->shouldBeCalledOnce()
+            ->willReturn($toolResponseMessage);
+
+        // Ensure executor is NOT called for metadata-only tool
+        $this->toolExecutor->execute(Argument::type(AIChatRequest::class), $metadataToolCall)
+            ->shouldNotBeCalled();
+
+        // Mock the updated request with tool response
+        $finalRequest = $this->prophesize(AIChatRequest::class);
+        $finalRequest->getMetadata()->willReturn(['key' => 'final']);
+        $updatedRequest->withMessage($toolResponseMessage)->willReturn($finalRequest->reveal());
+
+        // Mock the next middleware response
+        $secondResponse = new AIChatResponse(
+            $finalRequest->reveal(),
+            new AIChatResponseMessage(AIChatMessageRoleEnum::ASSISTANT, 'Final response'),
+            new Usage(5, 10, 15),
+        );
+
+        $nextMiddleware = function () use ($secondResponse) {
+            return $secondResponse;
+        };
+
+        $decorator = new ToolResponseDecorator(
+            $response,
+            $this->request->reveal(),
+            $this->adapter->reveal(),
+            $nextMiddleware,
+            $this->toolExecutor->reveal(),
+            self::MAX_TOOL_EXECUTIONS,
+        );
+
+        $result = $decorator->processToolCalls();
+
+        $this->assertInstanceOf(ToolResponseDecorator::class, $result);
     }
 }

--- a/packages/chat/tests/Unit/Middleware/Tools/ToolStreamResponseDecoratorTest.php
+++ b/packages/chat/tests/Unit/Middleware/Tools/ToolStreamResponseDecoratorTest.php
@@ -59,6 +59,7 @@ class ToolStreamResponseDecoratorTest extends TestCase
         $this->toolExecutor = $this->prophesize(ToolExecutor::class);
 
         $this->request->getMetadata()->willReturn(['key' => 'value']);
+        $this->request->getTools()->willReturn([]);
     }
 
     public function testGetMessageReturnsOriginalMessage(): void
@@ -275,6 +276,9 @@ class ToolStreamResponseDecoratorTest extends TestCase
 
     public function testGetMessageStreamWithToolCalls(): void
     {
+        // Mock getTools() to include the tool
+        $this->request->getTools()->willReturn(['tool_name' => [(object) [], 'method']]);
+
         // Create a tool call
         $toolCall = new AIChatToolCall(
             ToolTypeEnum::FUNCTION,
@@ -309,6 +313,7 @@ class ToolStreamResponseDecoratorTest extends TestCase
 
         // Mock the request handling
         $updatedRequest = $this->prophesize(AIChatStreamedRequest::class);
+        $updatedRequest->getTools()->willReturn(['tool_name' => [(object) [], 'method']]);
         $this->request->withMessage(Argument::type(AIChatMessage::class))
             ->willReturn($updatedRequest->reveal());
 
@@ -374,6 +379,12 @@ class ToolStreamResponseDecoratorTest extends TestCase
 
     public function testGetMessageStreamWithNestedToolCalls(): void
     {
+        // Mock getTools() to include both tools
+        $this->request->getTools()->willReturn([
+            'first_tool' => [(object) [], 'method1'],
+            'second_tool' => [(object) [], 'method2'],
+        ]);
+
         // Create two tool calls
         $toolCall1 = new AIChatToolCall(
             ToolTypeEnum::FUNCTION,
@@ -409,6 +420,10 @@ class ToolStreamResponseDecoratorTest extends TestCase
 
         // Mock the request handling for first call
         $updatedRequest1 = $this->prophesize(AIChatStreamedRequest::class);
+        $updatedRequest1->getTools()->willReturn([
+            'first_tool' => [(object) [], 'method1'],
+            'second_tool' => [(object) [], 'method2'],
+        ]);
         $this->request->withMessage(Argument::type(AIChatMessage::class))
             ->willReturn($updatedRequest1->reveal());
 
@@ -422,6 +437,10 @@ class ToolStreamResponseDecoratorTest extends TestCase
             ->willReturn($toolResponseMessage1);
 
         $finalRequest1 = $this->prophesize(AIChatStreamedRequest::class);
+        $finalRequest1->getTools()->willReturn([
+            'first_tool' => [(object) [], 'method1'],
+            'second_tool' => [(object) [], 'method2'],
+        ]);
         $updatedRequest1->withMessage($toolResponseMessage1)->willReturn($finalRequest1->reveal());
         $finalRequest1->getMetadata()->willReturn(['key' => 'final1']);
 
@@ -444,6 +463,10 @@ class ToolStreamResponseDecoratorTest extends TestCase
 
         // Mock the request handling for second call
         $updatedRequest2 = $this->prophesize(AIChatStreamedRequest::class);
+        $updatedRequest2->getTools()->willReturn([
+            'first_tool' => [(object) [], 'method1'],
+            'second_tool' => [(object) [], 'method2'],
+        ]);
         $finalRequest1->withMessage(Argument::type(AIChatMessage::class))
             ->willReturn($updatedRequest2->reveal());
 
@@ -514,6 +537,9 @@ class ToolStreamResponseDecoratorTest extends TestCase
 
     public function testGetMessageStreamRespectsMaxExecutions(): void
     {
+        // Mock getTools() to include the tool
+        $this->request->getTools()->willReturn(['recursive_tool' => [(object) [], 'method']]);
+
         // Create a tool call that will be used in a loop
         $toolCall = new AIChatToolCall(
             ToolTypeEnum::FUNCTION,
@@ -542,6 +568,7 @@ class ToolStreamResponseDecoratorTest extends TestCase
 
         // Mock the request handling
         $updatedRequest = $this->prophesize(AIChatStreamedRequest::class);
+        $updatedRequest->getTools()->willReturn(['recursive_tool' => [(object) [], 'method']]);
         $this->request->withMessage(Argument::type(AIChatMessage::class))
             ->willReturn($updatedRequest->reveal());
 
@@ -555,6 +582,7 @@ class ToolStreamResponseDecoratorTest extends TestCase
             ->willReturn($toolResponseMessage);
 
         $finalRequest = $this->prophesize(AIChatStreamedRequest::class);
+        $finalRequest->getTools()->willReturn(['recursive_tool' => [(object) [], 'method']]);
         $updatedRequest->withMessage(Argument::any())->willReturn($finalRequest->reveal());
         $finalRequest->withMessage(Argument::any())->willReturn($finalRequest->reveal());
         $finalRequest->getMetadata()->willReturn(['key' => 'final']);

--- a/packages/chat/tests/Unit/Request/Builder/AIChatRequestBuilderTest.php
+++ b/packages/chat/tests/Unit/Request/Builder/AIChatRequestBuilderTest.php
@@ -24,6 +24,7 @@ use ModelflowAi\Chat\Response\AIChatResponseMessage;
 use ModelflowAi\Chat\Response\AIChatResponseStream;
 use ModelflowAi\Chat\ToolInfo\ToolChoiceEnum;
 use ModelflowAi\Chat\ToolInfo\ToolInfo;
+use ModelflowAi\Chat\ToolInfo\ToolTypeEnum;
 use ModelflowAi\DecisionTree\Criteria\CapabilityCriteria;
 use ModelflowAi\DecisionTree\Criteria\FeatureCriteria;
 use PHPUnit\Framework\TestCase;
@@ -270,6 +271,194 @@ class AIChatRequestBuilderTest extends TestCase
 
         $response = $builder->execute();
         $this->assertInstanceOf(AIChatResponseStream::class, $response);
+    }
+
+    public function testAddToolInfo(): void
+    {
+        $builder = new AIChatRequestBuilder(fn () => null);
+
+        $toolInfo = new ToolInfo(
+            ToolTypeEnum::FUNCTION,
+            'external_tool',
+            'A tool executed externally',
+            [],
+            [],
+        );
+
+        $builder->addToolInfo($toolInfo);
+
+        $request = $builder->build();
+        $toolInfos = $request->getToolInfos();
+
+        $this->assertCount(1, $toolInfos);
+        $this->assertSame('external_tool', $toolInfos[0]->name);
+        $this->assertSame('A tool executed externally', $toolInfos[0]->description);
+
+        // Verify it's not in executable tools
+        $this->assertEmpty($request->getTools());
+    }
+
+    public function testAddToolInfoWithInstanceBasedTool(): void
+    {
+        $builder = new AIChatRequestBuilder(fn () => null);
+
+        // Add instance-based tool first
+        $builder->tool('instance_tool', $this, 'toolMethod');
+
+        // Add direct ToolInfo
+        $toolInfo = new ToolInfo(
+            ToolTypeEnum::FUNCTION,
+            'direct_tool',
+            'Direct tool',
+            [],
+            [],
+        );
+        $builder->addToolInfo($toolInfo);
+
+        $request = $builder->build();
+
+        // Should have 2 ToolInfos
+        $this->assertCount(2, $request->getToolInfos());
+
+        // But only 1 executable tool
+        $this->assertCount(1, $request->getTools());
+        $this->assertArrayHasKey('instance_tool', $request->getTools());
+        $this->assertArrayNotHasKey('direct_tool', $request->getTools());
+    }
+
+    public function testAddToolInfoThrowsOnDuplicateName(): void
+    {
+        $builder = new AIChatRequestBuilder(fn () => null);
+
+        $toolInfo1 = new ToolInfo(
+            ToolTypeEnum::FUNCTION,
+            'duplicate',
+            'First tool',
+            [],
+            [],
+        );
+
+        $toolInfo2 = new ToolInfo(
+            ToolTypeEnum::FUNCTION,
+            'duplicate',
+            'Second tool',
+            [],
+            [],
+        );
+
+        $builder->addToolInfo($toolInfo1);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Tool with name "duplicate" already exists');
+
+        $builder->addToolInfo($toolInfo2);
+    }
+
+    public function testAddToolInfoThrowsWhenConflictsWithInstanceTool(): void
+    {
+        $builder = new AIChatRequestBuilder(fn () => null);
+
+        // Add instance-based tool
+        $builder->tool('conflict_name', $this, 'toolMethod');
+
+        // Try to add ToolInfo with same name
+        $toolInfo = new ToolInfo(
+            ToolTypeEnum::FUNCTION,
+            'conflict_name',
+            'Conflicting tool',
+            [],
+            [],
+        );
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Tool with name "conflict_name" already exists as executable tool');
+
+        $builder->addToolInfo($toolInfo);
+    }
+
+    public function testToolThrowsWhenConflictsWithDirectToolInfo(): void
+    {
+        $builder = new AIChatRequestBuilder(fn () => null);
+
+        // Add direct ToolInfo first
+        $toolInfo = new ToolInfo(
+            ToolTypeEnum::FUNCTION,
+            'conflict_name',
+            'Direct tool',
+            [],
+            [],
+        );
+        $builder->addToolInfo($toolInfo);
+
+        // Try to add instance tool with same name
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Tool with name "conflict_name" already exists as direct ToolInfo');
+
+        $builder->tool('conflict_name', $this, 'toolMethod');
+    }
+
+    public function testMultipleDirectToolInfos(): void
+    {
+        $builder = new AIChatRequestBuilder(fn () => null);
+
+        $toolInfo1 = new ToolInfo(
+            ToolTypeEnum::FUNCTION,
+            'tool1',
+            'First tool',
+            [],
+            [],
+        );
+
+        $toolInfo2 = new ToolInfo(
+            ToolTypeEnum::FUNCTION,
+            'tool2',
+            'Second tool',
+            [],
+            [],
+        );
+
+        $builder->addToolInfo($toolInfo1)
+               ->addToolInfo($toolInfo2);
+
+        $request = $builder->build();
+
+        $this->assertCount(2, $request->getToolInfos());
+        $this->assertEmpty($request->getTools());
+    }
+
+    public function testToolInfoOrderPreservation(): void
+    {
+        $builder = new AIChatRequestBuilder(fn () => null);
+
+        // Add instance tool first
+        $builder->tool('instance_tool', $this, 'toolMethod');
+
+        // Add direct ToolInfos
+        $toolInfo1 = new ToolInfo(
+            ToolTypeEnum::FUNCTION,
+            'direct_tool_1',
+            'Direct tool 1',
+            [],
+            [],
+        );
+        $toolInfo2 = new ToolInfo(
+            ToolTypeEnum::FUNCTION,
+            'direct_tool_2',
+            'Direct tool 2',
+            [],
+            [],
+        );
+
+        $builder->addToolInfo($toolInfo1)
+               ->addToolInfo($toolInfo2);
+
+        $request = $builder->build();
+        $toolInfos = $request->getToolInfos();
+
+        // Instance-based tools should come first (from buildToolInfos)
+        $this->assertSame('instance_tool', $toolInfos[0]->name);
+        $this->assertSame('direct_tool_1', $toolInfos[1]->name);
+        $this->assertSame('direct_tool_2', $toolInfos[2]->name);
     }
 
     public function toolMethod(string $test): string


### PR DESCRIPTION
This change enables adding ToolInfo directly to requests without requiring an object instance for execution. This is useful for tools that are executed externally or when tools need to be sent to AI for awareness but execution is handled outside the system.

Changes:
- Add addToolInfo() method to AIChatRequestBuilder
- Store direct ToolInfos separately from executable tools
- Modify buildToolInfos() to merge both instance-based and direct ToolInfos
- Add bidirectional validation to prevent tool name conflicts
- Update ToolExecutor to handle metadata-only tools gracefully
- Return JSON null for metadata-only tools instead of throwing exceptions

The implementation maintains full backward compatibility. Executable tools (added via tool() method) and metadata-only tools (added via addToolInfo()) can coexist in the same request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for registering tools as metadata-only entries in requests and merging them with executable tools while preserving ordering.
  * Request processing now ignores tool calls not explicitly registered in the request.

* **Bug Fixes**
  * Enforced uniqueness of tool names across all registration methods to prevent conflicts.

* **Tests**
  * Expanded coverage for registration, conflict detection, ordering, and execution filtering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->