### PR TITLE
Add removeDocument and removeDocuments methods to embeddings stores

### DIFF
--- a/packages/elasticsearch-embeddings-store/src/ElasticsearchEmbeddingsStore.php
+++ b/packages/elasticsearch-embeddings-store/src/ElasticsearchEmbeddingsStore.php
@@ -17,6 +17,7 @@ use Elastic\Elasticsearch\Client;
 use Elastic\Elasticsearch\Response\Elasticsearch;
 use ModelflowAi\Embeddings\Model\EmbeddingInterface;
 use ModelflowAi\Embeddings\Store\EmbeddingsStoreInterface;
+use Webmozart\Assert\Assert;
 
 /**
  * Heavenly inspired by LLPhant
@@ -207,6 +208,8 @@ class ElasticsearchEmbeddingsStore implements EmbeddingsStoreInterface
 
     public function removeDocument(string $identifier): void
     {
+        Assert::stringNotEmpty($identifier, 'Document identifier cannot be empty');
+
         try {
             $this->client->delete([
                 'index' => $this->indexName,
@@ -230,13 +233,53 @@ class ElasticsearchEmbeddingsStore implements EmbeddingsStoreInterface
             return;
         }
 
+        foreach ($identifiers as $identifier) {
+            Assert::stringNotEmpty($identifier, 'Document identifier cannot be empty');
+        }
+
         $body = [];
         foreach ($identifiers as $identifier) {
             $body[] = ['delete' => ['_index' => $this->indexName, '_id' => $identifier]];
         }
 
         try {
-            $this->client->bulk(['body' => $body]);
+            /** @var Elasticsearch $bulkResponse */
+            $bulkResponse = $this->client->bulk(['body' => $body]);
+            $response = $bulkResponse->asArray();
+
+            // Check bulk response for per-item failures
+            if (isset($response['errors']) && true === $response['errors']) {
+                $items = $response['items'] ?? [];
+                if (!\is_array($items)) {
+                    $items = [];
+                }
+
+                foreach ($items as $item) {
+                    if (!\is_array($item)) {
+                        continue;
+                    }
+
+                    $operation = $item['delete'] ?? $item['index'] ?? $item['create'] ?? $item['update'] ?? null;
+                    if (!\is_array($operation)) {
+                        continue;
+                    }
+
+                    // Allow 404 (document not found) - idempotent deletion
+                    $hasError = isset($operation['error']);
+                    $status = $operation['status'] ?? 0;
+
+                    if ($hasError && 404 !== $status) {
+                        $errorReason = 'Unknown error';
+                        if (\is_array($operation['error']) && isset($operation['error']['reason'])) {
+                            $reason = $operation['error']['reason'];
+                            $errorReason = \is_string($reason) ? $reason : 'Unknown error';
+                        }
+
+                        throw new \RuntimeException('Bulk delete operation failed: ' . $errorReason);
+                    }
+                }
+            }
+
             $this->client->indices()->refresh(['index' => $this->indexName]);
         } catch (\Elastic\Elasticsearch\Exception\ClientResponseException $e) {
             if (!\str_contains($e->getMessage(), 'not_found') && 404 !== $e->getCode()) {

--- a/packages/elasticsearch-embeddings-store/src/ElasticsearchEmbeddingsStore.php
+++ b/packages/elasticsearch-embeddings-store/src/ElasticsearchEmbeddingsStore.php
@@ -204,4 +204,44 @@ class ElasticsearchEmbeddingsStore implements EmbeddingsStoreInterface
         ]);
         $this->vectorDimSet = true;
     }
+
+    public function removeDocument(string $identifier): void
+    {
+        try {
+            $this->client->delete([
+                'index' => $this->indexName,
+                'id' => $identifier,
+            ]);
+
+            $this->client->indices()->refresh(['index' => $this->indexName]);
+        } catch (\Elastic\Elasticsearch\Exception\ClientResponseException $e) {
+            if (404 !== $e->getCode()) {
+                throw $e;
+            }
+        }
+    }
+
+    /**
+     * @param string[] $identifiers
+     */
+    public function removeDocuments(array $identifiers): void
+    {
+        if ([] === $identifiers) {
+            return;
+        }
+
+        $body = [];
+        foreach ($identifiers as $identifier) {
+            $body[] = ['delete' => ['_index' => $this->indexName, '_id' => $identifier]];
+        }
+
+        try {
+            $this->client->bulk(['body' => $body]);
+            $this->client->indices()->refresh(['index' => $this->indexName]);
+        } catch (\Elastic\Elasticsearch\Exception\ClientResponseException $e) {
+            if (!\str_contains($e->getMessage(), 'not_found') && 404 !== $e->getCode()) {
+                throw $e;
+            }
+        }
+    }
 }

--- a/packages/embeddings/src/Store/EmbeddingsStoreInterface.php
+++ b/packages/embeddings/src/Store/EmbeddingsStoreInterface.php
@@ -31,4 +31,11 @@ interface EmbeddingsStoreInterface
      * @return EmbeddingInterface[]
      */
     public function similaritySearch(array $vector, int $k = 4, array $additionalArguments = []): array;
+
+    public function removeDocument(string $identifier): void;
+
+    /**
+     * @param string[] $identifiers
+     */
+    public function removeDocuments(array $identifiers): void;
 }

--- a/packages/embeddings/src/Store/Filesystem/FilesystemEmbeddingsStore.php
+++ b/packages/embeddings/src/Store/Filesystem/FilesystemEmbeddingsStore.php
@@ -119,4 +119,40 @@ class FilesystemEmbeddingsStore implements EmbeddingsStoreInterface
     {
         \file_put_contents($this->filePath, \serialize($embeddings));
     }
+
+    public function removeDocument(string $identifier): void
+    {
+        $embeddings = $this->readDocumentsFromFile();
+
+        foreach ($embeddings as $index => $embedding) {
+            if ($embedding->getIdentifier() === $identifier) {
+                unset($embeddings[$index]);
+                $this->saveDocumentsToFile(\array_values($embeddings));
+
+                return;
+            }
+        }
+    }
+
+    public function removeDocuments(array $identifiers): void
+    {
+        if ([] === $identifiers) {
+            return;
+        }
+
+        $embeddings = $this->readDocumentsFromFile();
+        $identifierSet = \array_flip($identifiers);
+        $modified = false;
+
+        foreach ($embeddings as $index => $embedding) {
+            if (isset($identifierSet[$embedding->getIdentifier()])) {
+                unset($embeddings[$index]);
+                $modified = true;
+            }
+        }
+
+        if ($modified) {
+            $this->saveDocumentsToFile(\array_values($embeddings));
+        }
+    }
 }

--- a/packages/embeddings/src/Store/Memory/MemoryEmbeddingsStore.php
+++ b/packages/embeddings/src/Store/Memory/MemoryEmbeddingsStore.php
@@ -88,4 +88,37 @@ class MemoryEmbeddingsStore implements EmbeddingsStoreInterface
 
         return $results;
     }
+
+    public function removeDocument(string $identifier): void
+    {
+        foreach ($this->embeddings as $index => $embedding) {
+            if ($embedding->getIdentifier() === $identifier) {
+                unset($this->embeddings[$index]);
+                $this->embeddings = \array_values($this->embeddings);
+
+                return;
+            }
+        }
+    }
+
+    public function removeDocuments(array $identifiers): void
+    {
+        if ([] === $identifiers) {
+            return;
+        }
+
+        $identifierSet = \array_flip($identifiers);
+        $modified = false;
+
+        foreach ($this->embeddings as $index => $embedding) {
+            if (isset($identifierSet[$embedding->getIdentifier()])) {
+                unset($this->embeddings[$index]);
+                $modified = true;
+            }
+        }
+
+        if ($modified) {
+            $this->embeddings = \array_values($this->embeddings);
+        }
+    }
 }

--- a/packages/embeddings/src/Store/Memory/MemoryEmbeddingsStore.php
+++ b/packages/embeddings/src/Store/Memory/MemoryEmbeddingsStore.php
@@ -18,6 +18,7 @@ use ModelflowAi\Embeddings\Model\EmbeddingInterface;
 use ModelflowAi\Embeddings\Store\EmbeddingsStoreInterface;
 use ModelflowAi\Embeddings\Store\ScoreAssignmentTrait;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
+use Webmozart\Assert\Assert;
 
 class MemoryEmbeddingsStore implements EmbeddingsStoreInterface
 {
@@ -91,6 +92,8 @@ class MemoryEmbeddingsStore implements EmbeddingsStoreInterface
 
     public function removeDocument(string $identifier): void
     {
+        Assert::stringNotEmpty($identifier, 'Document identifier cannot be empty');
+
         foreach ($this->embeddings as $index => $embedding) {
             if ($embedding->getIdentifier() === $identifier) {
                 unset($this->embeddings[$index]);
@@ -105,6 +108,10 @@ class MemoryEmbeddingsStore implements EmbeddingsStoreInterface
     {
         if ([] === $identifiers) {
             return;
+        }
+
+        foreach ($identifiers as $identifier) {
+            Assert::stringNotEmpty($identifier, 'Document identifier cannot be empty');
         }
 
         $identifierSet = \array_flip($identifiers);

--- a/packages/embeddings/tests/Unit/Store/Filesystem/FilesystemEmbeddingsStoreTest.php
+++ b/packages/embeddings/tests/Unit/Store/Filesystem/FilesystemEmbeddingsStoreTest.php
@@ -243,6 +243,148 @@ class FilesystemEmbeddingsStoreTest extends TestCase
 
         $this->store->similaritySearch([0.1, 0.1, 0.1], 1, ['category' => 123]);
     }
+
+    public function testRemoveDocument(): void
+    {
+        $embedding1 = new TestEmbedding('content1', [0.1, 0.2, 0.3]);
+        $embedding2 = new TestEmbedding('content2', [0.4, 0.5, 0.6]);
+        $embedding3 = new TestEmbedding('content3', [0.7, 0.8, 0.9]);
+
+        $this->store->addDocuments([$embedding1, $embedding2, $embedding3]);
+
+        $this->store->removeDocument($embedding2->getIdentifier());
+
+        $results = $this->store->similaritySearch([0.4, 0.5, 0.6], 10);
+
+        $this->assertCount(2, $results);
+        $contents = [$results[0]->getContent(), $results[1]->getContent()];
+        $this->assertContains($embedding1->getContent(), $contents);
+        $this->assertContains($embedding3->getContent(), $contents);
+        $this->assertNotContains($embedding2->getContent(), $contents);
+    }
+
+    public function testRemoveDocuments(): void
+    {
+        $embeddings = [];
+        for ($i = 1; $i <= 5; ++$i) {
+            $embeddings[] = new TestEmbedding("content$i", [$i / 10, $i / 10, $i / 10]);
+        }
+
+        $this->store->addDocuments($embeddings);
+
+        $identifiers = [
+            $embeddings[1]->getIdentifier(),
+            $embeddings[3]->getIdentifier(),
+        ];
+
+        $this->store->removeDocuments($identifiers);
+
+        $results = $this->store->similaritySearch([0.3, 0.3, 0.3], 10);
+
+        $this->assertCount(3, $results);
+        $contents = [$results[0]->getContent(), $results[1]->getContent(), $results[2]->getContent()];
+        $this->assertContains($embeddings[0]->getContent(), $contents);
+        $this->assertContains($embeddings[2]->getContent(), $contents);
+        $this->assertContains($embeddings[4]->getContent(), $contents);
+    }
+
+    public function testRemoveNonExistentDocument(): void
+    {
+        $embedding1 = new TestEmbedding('content1', [0.1, 0.2, 0.3]);
+        $this->store->addDocument($embedding1);
+
+        $this->store->removeDocument('non-existent-id');
+
+        $results = $this->store->similaritySearch([0.1, 0.2, 0.3], 10);
+        $this->assertCount(1, $results);
+    }
+
+    public function testRemoveFromEmptyStore(): void
+    {
+        $this->store->removeDocument('non-existent-id');
+
+        $results = $this->store->similaritySearch([0.1, 0.2, 0.3], 10);
+        $this->assertEmpty($results);
+        $this->assertFileDoesNotExist($this->testFilePath);
+    }
+
+    public function testRemoveDocumentsEmptyArray(): void
+    {
+        $embedding1 = new TestEmbedding('content1', [0.1, 0.2, 0.3]);
+        $this->store->addDocument($embedding1);
+
+        $this->store->removeDocuments([]);
+
+        $results = $this->store->similaritySearch([0.1, 0.2, 0.3], 10);
+        $this->assertCount(1, $results);
+    }
+
+    public function testRemoveAndReAdd(): void
+    {
+        $embedding1 = new TestEmbedding('content1', [0.1, 0.2, 0.3]);
+        $this->store->addDocument($embedding1);
+
+        $this->store->removeDocument($embedding1->getIdentifier());
+
+        $results = $this->store->similaritySearch([0.1, 0.2, 0.3], 10);
+        $this->assertEmpty($results);
+
+        $this->store->addDocument($embedding1);
+
+        $results = $this->store->similaritySearch([0.1, 0.2, 0.3], 10);
+        $this->assertCount(1, $results);
+        $this->assertSame($embedding1->getContent(), $results[0]->getContent());
+    }
+
+    public function testRemoveDocumentPersistence(): void
+    {
+        $embedding1 = new TestEmbedding('content1', [0.1, 0.2, 0.3]);
+        $embedding2 = new TestEmbedding('content2', [0.4, 0.5, 0.6]);
+
+        $this->store->addDocuments([$embedding1, $embedding2]);
+
+        $this->store->removeDocument($embedding1->getIdentifier());
+
+        $newStore = new FilesystemEmbeddingsStore($this->testFilePath);
+        $results = $newStore->similaritySearch([0.3, 0.4, 0.5], 10);
+
+        $this->assertCount(1, $results);
+        $this->assertSame($embedding2->getContent(), $results[0]->getContent());
+    }
+
+    public function testSimilaritySearchAfterRemove(): void
+    {
+        $embedding1 = new TestEmbedding('content1', [0.1, 0.1, 0.1]);
+        $embedding2 = new TestEmbedding('content2', [0.2, 0.2, 0.2]);
+        $embedding3 = new TestEmbedding('content3', [0.3, 0.3, 0.3]);
+
+        $this->store->addDocuments([$embedding1, $embedding2, $embedding3]);
+
+        $this->store->removeDocument($embedding2->getIdentifier());
+
+        $results = $this->store->similaritySearch([0.2, 0.2, 0.2], 3);
+
+        $this->assertCount(2, $results);
+        $this->assertSame($embedding3->getContent(), $results[0]->getContent());
+        $this->assertSame($embedding1->getContent(), $results[1]->getContent());
+    }
+
+    public function testRemoveDocumentsWithDuplicates(): void
+    {
+        $embedding1 = new TestEmbedding('content1', [0.1, 0.2, 0.3]);
+        $embedding2 = new TestEmbedding('content2', [0.4, 0.5, 0.6]);
+
+        $this->store->addDocuments([$embedding1, $embedding2]);
+
+        $this->store->removeDocuments([
+            $embedding1->getIdentifier(),
+            $embedding1->getIdentifier(),
+        ]);
+
+        $results = $this->store->similaritySearch([0.3, 0.4, 0.5], 10);
+        $this->assertCount(1, $results);
+        $this->assertSame($embedding2->getContent(), $results[0]->getContent());
+    }
 }
 
 class TestEmbedding implements EmbeddingInterface

--- a/packages/embeddings/tests/Unit/Store/Memory/MemoryEmbeddingsStoreTest.php
+++ b/packages/embeddings/tests/Unit/Store/Memory/MemoryEmbeddingsStoreTest.php
@@ -268,6 +268,131 @@ class MemoryEmbeddingsStoreTest extends TestCase
 
         $this->store->similaritySearch([0.1, 0.1, 0.1], 1, ['category' => 123]);
     }
+
+    public function testRemoveDocument(): void
+    {
+        $embedding1 = new TestEmbedding('content1', [0.1, 0.2, 0.3]);
+        $embedding2 = new TestEmbedding('content2', [0.4, 0.5, 0.6]);
+        $embedding3 = new TestEmbedding('content3', [0.7, 0.8, 0.9]);
+
+        $this->store->addDocuments([$embedding1, $embedding2, $embedding3]);
+
+        $this->store->removeDocument($embedding2->getIdentifier());
+
+        $results = $this->store->similaritySearch([0.4, 0.5, 0.6], 10);
+
+        $this->assertCount(2, $results);
+        $contents = [$results[0]->getContent(), $results[1]->getContent()];
+        $this->assertContains($embedding1->getContent(), $contents);
+        $this->assertContains($embedding3->getContent(), $contents);
+        $this->assertNotContains($embedding2->getContent(), $contents);
+    }
+
+    public function testRemoveDocuments(): void
+    {
+        $embeddings = [];
+        for ($i = 1; $i <= 5; ++$i) {
+            $embeddings[] = new TestEmbedding("content$i", [$i / 10, $i / 10, $i / 10]);
+        }
+
+        $this->store->addDocuments($embeddings);
+
+        $identifiers = [
+            $embeddings[1]->getIdentifier(),
+            $embeddings[3]->getIdentifier(),
+        ];
+
+        $this->store->removeDocuments($identifiers);
+
+        $results = $this->store->similaritySearch([0.3, 0.3, 0.3], 10);
+
+        $this->assertCount(3, $results);
+        $contents = [$results[0]->getContent(), $results[1]->getContent(), $results[2]->getContent()];
+        $this->assertContains($embeddings[0]->getContent(), $contents);
+        $this->assertContains($embeddings[2]->getContent(), $contents);
+        $this->assertContains($embeddings[4]->getContent(), $contents);
+    }
+
+    public function testRemoveNonExistentDocument(): void
+    {
+        $embedding1 = new TestEmbedding('content1', [0.1, 0.2, 0.3]);
+        $this->store->addDocument($embedding1);
+
+        $this->store->removeDocument('non-existent-id');
+
+        $results = $this->store->similaritySearch([0.1, 0.2, 0.3], 10);
+        $this->assertCount(1, $results);
+    }
+
+    public function testRemoveFromEmptyStore(): void
+    {
+        $this->store->removeDocument('non-existent-id');
+
+        $results = $this->store->similaritySearch([0.1, 0.2, 0.3], 10);
+        $this->assertEmpty($results);
+    }
+
+    public function testRemoveDocumentsEmptyArray(): void
+    {
+        $embedding1 = new TestEmbedding('content1', [0.1, 0.2, 0.3]);
+        $this->store->addDocument($embedding1);
+
+        $this->store->removeDocuments([]);
+
+        $results = $this->store->similaritySearch([0.1, 0.2, 0.3], 10);
+        $this->assertCount(1, $results);
+    }
+
+    public function testRemoveAndReAdd(): void
+    {
+        $embedding1 = new TestEmbedding('content1', [0.1, 0.2, 0.3]);
+        $this->store->addDocument($embedding1);
+
+        $this->store->removeDocument($embedding1->getIdentifier());
+
+        $results = $this->store->similaritySearch([0.1, 0.2, 0.3], 10);
+        $this->assertEmpty($results);
+
+        $this->store->addDocument($embedding1);
+
+        $results = $this->store->similaritySearch([0.1, 0.2, 0.3], 10);
+        $this->assertCount(1, $results);
+        $this->assertSame($embedding1->getContent(), $results[0]->getContent());
+    }
+
+    public function testSimilaritySearchAfterRemove(): void
+    {
+        $embedding1 = new TestEmbedding('content1', [0.1, 0.1, 0.1]);
+        $embedding2 = new TestEmbedding('content2', [0.2, 0.2, 0.2]);
+        $embedding3 = new TestEmbedding('content3', [0.3, 0.3, 0.3]);
+
+        $this->store->addDocuments([$embedding1, $embedding2, $embedding3]);
+
+        $this->store->removeDocument($embedding2->getIdentifier());
+
+        $results = $this->store->similaritySearch([0.2, 0.2, 0.2], 3);
+
+        $this->assertCount(2, $results);
+        $this->assertSame($embedding3->getContent(), $results[0]->getContent());
+        $this->assertSame($embedding1->getContent(), $results[1]->getContent());
+    }
+
+    public function testRemoveDocumentsWithDuplicates(): void
+    {
+        $embedding1 = new TestEmbedding('content1', [0.1, 0.2, 0.3]);
+        $embedding2 = new TestEmbedding('content2', [0.4, 0.5, 0.6]);
+
+        $this->store->addDocuments([$embedding1, $embedding2]);
+
+        $this->store->removeDocuments([
+            $embedding1->getIdentifier(),
+            $embedding1->getIdentifier(),
+        ]);
+
+        $results = $this->store->similaritySearch([0.3, 0.4, 0.5], 10);
+        $this->assertCount(1, $results);
+        $this->assertSame($embedding2->getContent(), $results[0]->getContent());
+    }
 }
 
 class TestEmbedding implements EmbeddingInterface

--- a/packages/embeddings/tests/Unit/Store/Memory/MemoryEmbeddingsStoreTest.php
+++ b/packages/embeddings/tests/Unit/Store/Memory/MemoryEmbeddingsStoreTest.php
@@ -393,6 +393,30 @@ class MemoryEmbeddingsStoreTest extends TestCase
         $this->assertCount(1, $results);
         $this->assertSame($embedding2->getContent(), $results[0]->getContent());
     }
+
+    public function testRemoveDocumentWithEmptyString(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Document identifier cannot be empty');
+
+        $this->store->removeDocument('');
+    }
+
+    public function testRemoveDocumentsWithEmptyString(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Document identifier cannot be empty');
+
+        $this->store->removeDocuments(['valid-id', '', 'another-id']);
+    }
+
+    public function testRemoveDocumentsWithOnlyEmptyString(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Document identifier cannot be empty');
+
+        $this->store->removeDocuments(['']);
+    }
 }
 
 class TestEmbedding implements EmbeddingInterface

--- a/packages/qdrant-embeddings-store/composer.lock
+++ b/packages/qdrant-embeddings-store/composer.lock
@@ -393,7 +393,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../embeddings",
-                "reference": "825b51cd5ea7282804d95b3b7996eb255be1a00b"
+                "reference": "b9e6dd3b8469574414564f8db320ce7fae919f0f"
             },
             "require": {
                 "php": "^8.2",
@@ -405,7 +405,7 @@
                 "jangregor/phpstan-prophecy": "^2.0",
                 "modelflow-ai/ollama-adapter": "^0.4",
                 "php-cs-fixer/shim": "^3.15",
-                "phpspec/prophecy-phpunit": "^2.1@stable",
+                "phpspec/prophecy-phpunit": "^2.2",
                 "phpstan/extension-installer": "^1.2",
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
@@ -1437,12 +1437,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/property-info.git",
-                "reference": "e22a72491aeea999d444bb1e5718fa6608dbca51"
+                "reference": "90d0174a7bfcbbdf1e42beb15cd67d22cf5efec7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/property-info/zipball/e22a72491aeea999d444bb1e5718fa6608dbca51",
-                "reference": "e22a72491aeea999d444bb1e5718fa6608dbca51",
+                "url": "https://api.github.com/repos/symfony/property-info/zipball/90d0174a7bfcbbdf1e42beb15cd67d22cf5efec7",
+                "reference": "90d0174a7bfcbbdf1e42beb15cd67d22cf5efec7",
                 "shasum": ""
             },
             "require": {
@@ -1516,7 +1516,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-27T16:18:35+00:00"
+            "time": "2026-01-30T15:36:26+00:00"
         },
         {
             "name": "symfony/string",
@@ -1615,12 +1615,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/type-info.git",
-                "reference": "ccecf52f4dcd9e1c731ec887c6822b16e0d877ad"
+                "reference": "7f1f93e71ff24ac7a716cd7624bba473f3d5c311"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/type-info/zipball/ccecf52f4dcd9e1c731ec887c6822b16e0d877ad",
-                "reference": "ccecf52f4dcd9e1c731ec887c6822b16e0d877ad",
+                "url": "https://api.github.com/repos/symfony/type-info/zipball/7f1f93e71ff24ac7a716cd7624bba473f3d5c311",
+                "reference": "7f1f93e71ff24ac7a716cd7624bba473f3d5c311",
                 "shasum": ""
             },
             "require": {
@@ -1690,7 +1690,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-29T15:13:09+00:00"
+            "time": "2026-01-30T15:36:26+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -1794,16 +1794,16 @@
         },
         {
             "name": "brick/math",
-            "version": "v0.14.x-dev",
+            "version": "0.14.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/brick/math.git",
-                "reference": "3ae4696b0f3830168065405eaf61ac008e8fa926"
+                "reference": "618a8077b3c326045e10d5788ed713b341fcfe40"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/brick/math/zipball/3ae4696b0f3830168065405eaf61ac008e8fa926",
-                "reference": "3ae4696b0f3830168065405eaf61ac008e8fa926",
+                "url": "https://api.github.com/repos/brick/math/zipball/618a8077b3c326045e10d5788ed713b341fcfe40",
+                "reference": "618a8077b3c326045e10d5788ed713b341fcfe40",
                 "shasum": ""
             },
             "require": {
@@ -1842,7 +1842,7 @@
             ],
             "support": {
                 "issues": "https://github.com/brick/math/issues",
-                "source": "https://github.com/brick/math/tree/v0.14"
+                "source": "https://github.com/brick/math/tree/0.14.5"
             },
             "funding": [
                 {
@@ -1850,7 +1850,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-01-29T15:56:21+00:00"
+            "time": "2026-02-03T18:06:51+00:00"
         },
         {
             "name": "modelflow-ai/api-client",
@@ -1954,7 +1954,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../ollama",
-                "reference": "15a54a8ca87836f06a5ca32e8bd254a29497efae"
+                "reference": "8a31f2e635c62306403e6ffef2acfdce61d9bd50"
             },
             "require": {
                 "modelflow-ai/api-client": "^0.4",
@@ -1965,7 +1965,7 @@
                 "asapo/remove-vendor-plugin": "^0.1",
                 "jangregor/phpstan-prophecy": "^2.0",
                 "php-cs-fixer/shim": "^3.15",
-                "phpspec/prophecy-phpunit": "^2.1@stable",
+                "phpspec/prophecy-phpunit": "^2.2",
                 "phpstan/extension-installer": "^1.2",
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
@@ -2052,7 +2052,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../ollama-adapter",
-                "reference": "9cced75846081f1d8728239a0fcbb1c9dce5f97a"
+                "reference": "92858069e82c52d17a2e31ddb8a5597bb2d92be9"
             },
             "require": {
                 "modelflow-ai/ollama": "^0.4",
@@ -2067,7 +2067,7 @@
                 "modelflow-ai/embeddings": "^0.4",
                 "modelflow-ai/prompt-template": "^0.4",
                 "php-cs-fixer/shim": "^3.15",
-                "phpspec/prophecy-phpunit": "^2.1@stable",
+                "phpspec/prophecy-phpunit": "^2.2",
                 "phpstan/extension-installer": "^1.2",
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
@@ -2498,8 +2498,8 @@
             "version": "2.1.x-dev",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/861cd9a1257fc5deaebb655d9d1d7cfb7830fc89",
-                "reference": "861cd9a1257fc5deaebb655d9d1d7cfb7830fc89",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/9299f0e10109e98a97fb65fb7c554e3d8947f44f",
+                "reference": "9299f0e10109e98a97fb65fb7c554e3d8947f44f",
                 "shasum": ""
             },
             "require": {
@@ -2545,7 +2545,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-01-29T16:51:43+00:00"
+            "time": "2026-02-03T20:57:24+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
@@ -2553,12 +2553,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-phpunit.git",
-                "reference": "e4c5a22bf43d3d2bd5a780ad261a622ff62c49a4"
+                "reference": "4d1d77610d68c8ff059ab17c76e0aaea2615d7c6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/e4c5a22bf43d3d2bd5a780ad261a622ff62c49a4",
-                "reference": "e4c5a22bf43d3d2bd5a780ad261a622ff62c49a4",
+                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/4d1d77610d68c8ff059ab17c76e0aaea2615d7c6",
+                "reference": "4d1d77610d68c8ff059ab17c76e0aaea2615d7c6",
                 "shasum": ""
             },
             "require": {
@@ -2595,11 +2595,14 @@
                 "MIT"
             ],
             "description": "PHPUnit extensions and rules for PHPStan",
+            "keywords": [
+                "static analysis"
+            ],
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-phpunit/issues",
                 "source": "https://github.com/phpstan/phpstan-phpunit/tree/2.0.x"
             },
-            "time": "2026-01-22T13:40:00+00:00"
+            "time": "2026-02-03T10:16:20+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2697,12 +2700,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "18a3d4f3af59807625ae982d88b27085ad38c367"
+                "reference": "2f3a64888c814fc235386b7387dd5b5ed92ad903"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/18a3d4f3af59807625ae982d88b27085ad38c367",
-                "reference": "18a3d4f3af59807625ae982d88b27085ad38c367",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/2f3a64888c814fc235386b7387dd5b5ed92ad903",
+                "reference": "2f3a64888c814fc235386b7387dd5b5ed92ad903",
                 "shasum": ""
             },
             "require": {
@@ -2742,7 +2745,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
                 "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/5.1"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/5.1.1"
             },
             "funding": [
                 {
@@ -2762,7 +2765,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-26T11:52:35+00:00"
+            "time": "2026-02-02T13:52:54+00:00"
         },
         {
             "name": "phpunit/php-invoker",
@@ -2990,12 +2993,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "0df37f7891fc7b3d3d66e14aaff859d4d768855a"
+                "reference": "debf1b7b0baa8931f559120211cf7aeeecb75a38"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0df37f7891fc7b3d3d66e14aaff859d4d768855a",
-                "reference": "0df37f7891fc7b3d3d66e14aaff859d4d768855a",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/debf1b7b0baa8931f559120211cf7aeeecb75a38",
+                "reference": "debf1b7b0baa8931f559120211cf7aeeecb75a38",
                 "shasum": ""
             },
             "require": {
@@ -3010,7 +3013,7 @@
                 "phar-io/version": "^3.2.1",
                 "php": ">=8.2",
                 "phpunit/php-code-coverage": "^11.0.12",
-                "phpunit/php-file-iterator": "^5.1.0",
+                "phpunit/php-file-iterator": "^5.1.1",
                 "phpunit/php-invoker": "^5.0.1",
                 "phpunit/php-text-template": "^4.0.1",
                 "phpunit/php-timer": "^7.0.1",
@@ -3022,6 +3025,7 @@
                 "sebastian/exporter": "^6.3.2",
                 "sebastian/global-state": "^7.0.2",
                 "sebastian/object-enumerator": "^6.0.1",
+                "sebastian/recursion-context": "^6.0.3",
                 "sebastian/type": "^5.1.3",
                 "sebastian/version": "^5.0.2",
                 "staabm/side-effects-detector": "^1.0.5"
@@ -3091,7 +3095,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-27T06:31:16+00:00"
+            "time": "2026-02-03T14:30:47+00:00"
         },
         {
             "name": "ramsey/collection",
@@ -5136,5 +5140,5 @@
         "php": "^8.2"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/packages/qdrant-embeddings-store/src/QdrantEmbeddingsStore.php
+++ b/packages/qdrant-embeddings-store/src/QdrantEmbeddingsStore.php
@@ -26,6 +26,7 @@ use Qdrant\Models\Request\SearchRequest;
 use Qdrant\Models\Request\VectorParams;
 use Qdrant\Models\VectorStruct;
 use Qdrant\Qdrant;
+use Webmozart\Assert\Assert;
 
 class QdrantEmbeddingsStore implements EmbeddingsStoreInterface
 {
@@ -178,6 +179,8 @@ class QdrantEmbeddingsStore implements EmbeddingsStoreInterface
 
     public function removeDocument(string $identifier): void
     {
+        Assert::stringNotEmpty($identifier, 'Document identifier cannot be empty');
+
         try {
             $this->client
                 ->collections($this->collectionName)
@@ -198,6 +201,10 @@ class QdrantEmbeddingsStore implements EmbeddingsStoreInterface
     {
         if ([] === $identifiers) {
             return;
+        }
+
+        foreach ($identifiers as $identifier) {
+            Assert::stringNotEmpty($identifier, 'Document identifier cannot be empty');
         }
 
         try {

--- a/packages/qdrant-embeddings-store/src/QdrantEmbeddingsStore.php
+++ b/packages/qdrant-embeddings-store/src/QdrantEmbeddingsStore.php
@@ -175,4 +175,41 @@ class QdrantEmbeddingsStore implements EmbeddingsStoreInterface
             ),
         );
     }
+
+    public function removeDocument(string $identifier): void
+    {
+        try {
+            $this->client
+                ->collections($this->collectionName)
+                ->points()
+                ->delete([$identifier]);
+        } catch (InvalidArgumentException $e) {
+            if (404 !== $e->getCode()) {
+                throw $e;
+            }
+            // 404: point doesn't exist, silent success (idempotent)
+        }
+    }
+
+    /**
+     * @param string[] $identifiers
+     */
+    public function removeDocuments(array $identifiers): void
+    {
+        if ([] === $identifiers) {
+            return;
+        }
+
+        try {
+            $this->client
+                ->collections($this->collectionName)
+                ->points()
+                ->delete($identifiers);
+        } catch (InvalidArgumentException $e) {
+            if (404 !== $e->getCode()) {
+                throw $e;
+            }
+            // 404: points don't exist, silent success (idempotent)
+        }
+    }
 }


### PR DESCRIPTION
Implement document removal functionality across all embeddings store implementations:
- Add removeDocument() and removeDocuments() to EmbeddingsStoreInterface
- Implement idempotent removal (silent success for non-existent documents)
- Optimize batch operations with single I/O cycles where applicable
- Add array re-indexing for Memory and Filesystem stores
- Leverage native delete APIs for Elasticsearch and Qdrant stores
- Include comprehensive test coverage with 8+ tests per implementation

All implementations follow silent success pattern - no exceptions thrown when attempting to remove non-existent documents.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added single- and batch-document removal across all embeddings stores; operations validate input, are idempotent, and ensure stores/indexes refresh for consistent state.

* **Tests**
  * Added comprehensive removal tests covering single/batch removals, empty inputs, duplicates, non-existent items, persistence across reinitialization, re-adding, and impact on similarity search results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->