### PR TITLE
Fix infinite loop when tool calls reference non-existent tools

### DIFF
--- a/packages/chat/src/Middleware/Tools/ToolResponseDecorator.php
+++ b/packages/chat/src/Middleware/Tools/ToolResponseDecorator.php
@@ -70,13 +70,19 @@ final class ToolResponseDecorator implements AIChatResponseInterface
             );
 
             // Execute each tool and add the tool response messages
+            $count = 0;
             foreach ($toolCalls as $toolCall) {
                 if (!\array_key_exists($toolCall->name, $request->getTools())) {
                     continue;
                 }
 
+                ++$count;
                 $toolResponseMessage = $this->toolExecutor->execute($request, $toolCall);
                 $request = $request->withMessage($toolResponseMessage);
+            }
+            if (0 === $count) {
+                // No valid tool calls executed, break to avoid infinite loop
+                break;
             }
 
             // Execute the request again

--- a/packages/chat/src/Middleware/Tools/ToolStreamResponseDecorator.php
+++ b/packages/chat/src/Middleware/Tools/ToolStreamResponseDecorator.php
@@ -79,9 +79,20 @@ final class ToolStreamResponseDecorator implements AIChatResponseStreamInterface
             );
 
             // Execute each tool and add the tool response messages
+            $count = 0;
             foreach ($toolCalls as $toolCall) {
+                if (!\array_key_exists($toolCall->name, $this->request->getTools())) {
+                    continue;
+                }
+
+                ++$count;
                 $toolResponseMessage = $this->toolExecutor->execute($this->request, $toolCall);
                 $this->request = $this->request->withMessage($toolResponseMessage);
+            }
+
+            if (0 === $count) {
+                // No valid tool calls executed, return early to avoid infinite loop
+                return;
             }
 
             // Execute the request again

--- a/packages/chat/src/Request/AIChatRequest.php
+++ b/packages/chat/src/Request/AIChatRequest.php
@@ -122,7 +122,7 @@ class AIChatRequest implements CriteriaBehaviour
 
     public function hasTools(): bool
     {
-        return [] !== $this->tools;
+        return [] !== $this->tools || [] !== $this->toolInfos;
     }
 
     /**

--- a/packages/chat/tests/Unit/Middleware/Tools/ToolResponseDecoratorTest.php
+++ b/packages/chat/tests/Unit/Middleware/Tools/ToolResponseDecoratorTest.php
@@ -564,4 +564,72 @@ class ToolResponseDecoratorTest extends TestCase
 
         $this->assertInstanceOf(ToolResponseDecorator::class, $result);
     }
+
+    public function testProcessToolCallsPreventsInfiniteLoopWhenAllToolCallsAreInvalid(): void
+    {
+        // Create tool calls for non-existent tools
+        $invalidToolCall1 = new AIChatToolCall(
+            ToolTypeEnum::FUNCTION,
+            'id_123',
+            'non_existent_tool_1',
+            ['param' => 'value1'],
+        );
+
+        $invalidToolCall2 = new AIChatToolCall(
+            ToolTypeEnum::FUNCTION,
+            'id_456',
+            'non_existent_tool_2',
+            ['param' => 'value2'],
+        );
+
+        $response = new AIChatResponse(
+            $this->request->reveal(),
+            new AIChatResponseMessage(AIChatMessageRoleEnum::ASSISTANT, 'Hello', [$invalidToolCall1, $invalidToolCall2]),
+            new Usage(5, 10, 15),
+        );
+
+        // Mock getTools() to return empty array (no tools available)
+        $this->request->getTools()->willReturn([]);
+
+        // Mock the request handling - should still be called once to add the assistant message
+        $updatedRequest = $this->prophesize(AIChatRequest::class);
+        $updatedRequest->getMetadata()->willReturn(['key' => 'updated']);
+        $updatedRequest->getTools()->willReturn([]);
+
+        $this->request->withMessage(Argument::type(AIChatMessage::class))
+            ->willReturn($updatedRequest->reveal());
+
+        // Tool executor should NEVER be called since all tools are invalid
+        $this->toolExecutor->execute(Argument::cetera())
+            ->shouldNotBeCalled();
+
+        // Next middleware should also NEVER be called because we break early
+        $middlewareCalled = false;
+        $nextMiddleware = function () use (&$middlewareCalled) {
+            $middlewareCalled = true;
+
+            return new AIChatResponse(
+                $this->request->reveal(),
+                new AIChatResponseMessage(AIChatMessageRoleEnum::ASSISTANT, 'Should not be called'),
+                Usage::empty(),
+            );
+        };
+
+        $decorator = new ToolResponseDecorator(
+            $response,
+            $this->request->reveal(),
+            $this->adapter->reveal(),
+            $nextMiddleware,
+            $this->toolExecutor->reveal(),
+            self::MAX_TOOL_EXECUTIONS,
+        );
+
+        $result = $decorator->processToolCalls();
+
+        $this->assertInstanceOf(ToolResponseDecorator::class, $result);
+        $this->assertFalse($middlewareCalled, 'Next middleware should not be called when all tool calls are invalid');
+
+        // Should return the original response since no valid tool calls were processed
+        $this->assertSame('Hello', $result->getMessage()->content);
+    }
 }

--- a/packages/chat/tests/Unit/Middleware/Tools/ToolStreamResponseDecoratorTest.php
+++ b/packages/chat/tests/Unit/Middleware/Tools/ToolStreamResponseDecoratorTest.php
@@ -665,4 +665,96 @@ class ToolStreamResponseDecoratorTest extends TestCase
         $resultMessages = \iterator_to_array($decorator->getMessageStream());
         $this->assertCount(1, $resultMessages);
     }
+
+    public function testGetMessageStreamPreventsInfiniteLoopWhenAllToolCallsAreInvalid(): void
+    {
+        // Create tool calls for non-existent tools
+        $invalidToolCall1 = new AIChatToolCall(
+            ToolTypeEnum::FUNCTION,
+            'id_123',
+            'non_existent_tool_1',
+            ['param' => 'value1'],
+        );
+
+        $invalidToolCall2 = new AIChatToolCall(
+            ToolTypeEnum::FUNCTION,
+            'id_456',
+            'non_existent_tool_2',
+            ['param' => 'value2'],
+        );
+
+        // Create message with invalid tool calls
+        $message = new AIChatResponseMessage(
+            AIChatMessageRoleEnum::ASSISTANT,
+            'Hello with invalid tools',
+            [$invalidToolCall1, $invalidToolCall2],
+        );
+
+        // Mock getTools() to return empty array (no tools available)
+        $this->request->getTools()->willReturn([]);
+
+        // Create original stream
+        $messageIterator = new \ArrayIterator([$message]);
+        $usageTracker = new StreamingUsageTracker();
+        $usageTracker->updateUsage(new Usage(10, 20, 30), true);
+        $originalStream = new AIChatResponseStream(
+            $this->request->reveal(),
+            $messageIterator,
+            [],
+            $usageTracker,
+        );
+
+        // Mock the request handling - should still be called once to add the assistant message
+        $updatedRequest = $this->prophesize(AIChatStreamedRequest::class);
+        $updatedRequest->getMetadata()->willReturn(['key' => 'updated']);
+        $updatedRequest->getTools()->willReturn([]);
+
+        $this->request->withMessage(Argument::type(AIChatMessage::class))
+            ->willReturn($updatedRequest->reveal());
+
+        // Tool executor should NEVER be called since all tools are invalid
+        $this->toolExecutor->execute(Argument::cetera())
+            ->shouldNotBeCalled();
+
+        // Next middleware should also NEVER be called because we return early
+        $middlewareCalled = false;
+        $nextMiddleware = function () use (&$middlewareCalled) {
+            $middlewareCalled = true;
+
+            $message = new AIChatResponseMessage(
+                AIChatMessageRoleEnum::ASSISTANT,
+                'Should not be called',
+                null,
+            );
+
+            $usageTracker = new StreamingUsageTracker();
+            $usageTracker->updateUsage(Usage::empty(), true);
+
+            return new AIChatResponseStream(
+                $this->request->reveal(),
+                new \ArrayIterator([$message]),
+                [],
+                $usageTracker,
+            );
+        };
+
+        $decorator = new ToolStreamResponseDecorator(
+            $originalStream,
+            $this->request->reveal(),
+            $this->adapter->reveal(),
+            $nextMiddleware,
+            $this->toolExecutor->reveal(),
+            self::MAX_TOOL_EXECUTIONS,
+        );
+
+        $resultMessages = \iterator_to_array($decorator->getMessageStream());
+
+        // Should only return the original message, no nested stream processing
+        $this->assertCount(1, $resultMessages);
+        $this->assertSame($message, $resultMessages[0]);
+        $this->assertFalse($middlewareCalled, 'Next middleware should not be called when all tool calls are invalid');
+
+        // Should only have original usage, no accumulated usage from nested streams
+        $this->assertSame(30, $decorator->getUsage()?->totalTokens);
+    }
 }

--- a/packages/chat/tests/Unit/Request/AIChatRequestTest.php
+++ b/packages/chat/tests/Unit/Request/AIChatRequestTest.php
@@ -213,6 +213,42 @@ class AIChatRequestTest extends TestCase
         $this->assertTrue($request->hasTools());
     }
 
+    public function testHasToolsWithOnlyToolInfos(): void
+    {
+        $toolInfos = [
+            ToolInfoBuilder::buildToolInfo($this, 'toolMethod', 'test_tool'),
+        ];
+
+        $requestHandler = fn () => null;
+        $request = new AIChatRequest(
+            new AIChatMessageCollection(),
+            new CriteriaCollection(),
+            [], // No tools
+            $toolInfos, // Only toolInfos
+            [],
+            $requestHandler,
+        );
+
+        $this->assertTrue($request->hasTools(), 'hasTools should return true when only toolInfos are present');
+        $this->assertEmpty($request->getTools());
+        $this->assertNotEmpty($request->getToolInfos());
+    }
+
+    public function testHasToolsWithNoToolsAndNoToolInfos(): void
+    {
+        $requestHandler = fn () => null;
+        $request = new AIChatRequest(
+            new AIChatMessageCollection(),
+            new CriteriaCollection(),
+            [], // No tools
+            [], // No toolInfos
+            [],
+            $requestHandler,
+        );
+
+        $this->assertFalse($request->hasTools(), 'hasTools should return false when both tools and toolInfos are empty');
+    }
+
     public function testIsStreamed(): void
     {
         $request = new AIChatRequest(


### PR DESCRIPTION
Prevent infinite loops in both ToolResponseDecorator and ToolStreamResponseDecorator when all tool calls reference tools that don't exist in the request.

Changes:
- Add validation counter to track valid tool executions
- Break/return early if no valid tools were executed
- Update hasTools() to check both tools and toolInfos arrays

Tests:
- Add tests for infinite loop prevention in both decorators
- Add tests for hasTools() with different combinations of tools/toolInfos

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential infinite loops when processing tool calls that reference non-existent or unavailable tools, improving system stability
  * Enhanced tool availability detection to recognize all configured tool information sources in requests

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->