### PR TITLE
Improve OptimisticJsonParser with incomplete value handling

### DIFF
--- a/packages/chat/src/Util/Json/OptimisticJsonParser.php
+++ b/packages/chat/src/Util/Json/OptimisticJsonParser.php
@@ -35,6 +35,8 @@ class OptimisticJsonParser
         $data = @\json_decode($fixedJsonString, true);
 
         if (\JSON_ERROR_NONE === \json_last_error()) {
+            $errorMessage = null;
+
             return $data;
         }
 
@@ -52,9 +54,8 @@ class OptimisticJsonParser
 
         $jsonString = self::closeUnclosedStrings($jsonString);
         $jsonString = self::fixIncompleteValues($jsonString);
-        $jsonString = self::closeUnclosedStructures($jsonString);
 
-        return $jsonString;
+        return self::closeUnclosedStructures($jsonString);
     }
 
     private static function closeUnclosedStrings(string $jsonString): string

--- a/packages/chat/src/Util/Json/OptimisticJsonParser.php
+++ b/packages/chat/src/Util/Json/OptimisticJsonParser.php
@@ -15,89 +15,50 @@ namespace ModelflowAi\Chat\Util\Json;
 
 class OptimisticJsonParser
 {
-    /**
-     * Parse a JSON string with best-effort parsing.
-     *
-     * @param string $jsonString the JSON string to parse
-     *
-     * @return mixed the parsed JSON data
-     */
     public static function parse(string $jsonString, ?string &$errorMessage = null): mixed
     {
-        // Attempt to decode the JSON string
         $data = @\json_decode($jsonString, true);
 
-        // Check if decoding was successful
         if (\JSON_ERROR_NONE === \json_last_error()) {
             return $data;
         }
 
         $errorMessage = \json_last_error_msg();
 
-        // If decoding failed, attempt to fix and parse the JSON
-        return self::fixAndParseJson($jsonString);
+        return self::fixAndParseJson($jsonString, $errorMessage);
     }
 
-    /**
-     * Attempt to fix and parse an incomplete JSON string.
-     *
-     * @param string $jsonString the incomplete JSON string
-     *
-     * @return mixed the parsed JSON data
-     */
     private static function fixAndParseJson(string $jsonString, ?string &$errorMessage = null): mixed
     {
-        // Attempt to fix common JSON issues
         $fixedJsonString = self::fixJsonSyntax($jsonString);
 
-        // Attempt to decode the fixed JSON string
         $data = @\json_decode($fixedJsonString, true);
 
-        // Check if decoding was successful
         if (\JSON_ERROR_NONE === \json_last_error()) {
             return $data;
         }
 
         $errorMessage = \json_last_error_msg();
 
-        // If decoding still fails, return null or handle the error
         return null;
     }
 
-    /**
-     * Attempt to fix common JSON syntax issues.
-     *
-     * @param string $jsonString the JSON string with potential syntax issues
-     *
-     * @return string the fixed JSON string
-     */
     private static function fixJsonSyntax(string $jsonString): string
     {
-        // Remove trailing commas
         $jsonString = \preg_replace('/,\s*([\]}])/', '$1', $jsonString);
         if (null === $jsonString) {
             throw new \RuntimeException('Error while fixing JSON syntax');
         }
 
-        // Attempt to close unclosed strings
         $jsonString = self::closeUnclosedStrings($jsonString);
-
-        // Attempt to close unclosed objects or arrays
+        $jsonString = self::fixIncompleteValues($jsonString);
         $jsonString = self::closeUnclosedStructures($jsonString);
 
         return $jsonString;
     }
 
-    /**
-     * Attempt to close unclosed strings in a JSON string.
-     *
-     * @param string $jsonString the JSON string with potential unclosed strings
-     *
-     * @return string the JSON string with closed strings
-     */
     private static function closeUnclosedStrings(string $jsonString): string
     {
-        // Track open quotes
         $inString = false;
         $escaped = false;
         $fixedString = '';
@@ -114,7 +75,6 @@ class OptimisticJsonParser
             $fixedString .= $char;
         }
 
-        // If string is unclosed, close it
         if ($inString) {
             $fixedString .= '"';
         }
@@ -123,15 +83,46 @@ class OptimisticJsonParser
     }
 
     /**
-     * Attempt to close unclosed objects or arrays in a JSON string.
-     *
-     * @param string $jsonString the JSON string with potential unclosed structures
-     *
-     * @return string the JSON string with closed structures
+     * Fix incomplete values such as dangling colons, partial literals, and trailing commas.
      */
+    private static function fixIncompleteValues(string $jsonString): string
+    {
+        $trimmed = \rtrim($jsonString);
+
+        // Dangling colon: {"key": → {"key": null
+        if (\preg_match('/:\s*$/', $trimmed)) {
+            $jsonString = $trimmed . 'null';
+        }
+
+        // Partial boolean/null literals in value position
+        $trimmed = \rtrim($jsonString);
+        if (\preg_match('/([\s:,\[\{])tru$/i', $trimmed)) {
+            $jsonString = \substr($trimmed, 0, -3) . 'true';
+        } elseif (\preg_match('/([\s:,\[\{])tr$/i', $trimmed)) {
+            $jsonString = \substr($trimmed, 0, -2) . 'true';
+        } elseif (\preg_match('/([\s:,\[\{])fals$/i', $trimmed)) {
+            $jsonString = \substr($trimmed, 0, -4) . 'false';
+        } elseif (\preg_match('/([\s:,\[\{])fal$/i', $trimmed)) {
+            $jsonString = \substr($trimmed, 0, -3) . 'false';
+        } elseif (\preg_match('/([\s:,\[\{])fa$/i', $trimmed)) {
+            $jsonString = \substr($trimmed, 0, -2) . 'false';
+        } elseif (\preg_match('/([\s:,\[\{])nul$/i', $trimmed)) {
+            $jsonString = \substr($trimmed, 0, -3) . 'null';
+        } elseif (\preg_match('/([\s:,\[\{])nu$/i', $trimmed)) {
+            $jsonString = \substr($trimmed, 0, -2) . 'null';
+        }
+
+        // Trailing comma before end of string (will be followed by structure closure)
+        $trimmed = \rtrim($jsonString);
+        if (\preg_match('/,\s*$/', $trimmed)) {
+            $jsonString = \preg_replace('/,\s*$/', '', $trimmed) ?? $trimmed;
+        }
+
+        return $jsonString;
+    }
+
     private static function closeUnclosedStructures(string $jsonString): string
     {
-        // Track open brackets and track structure properly
         $stack = [];
         $inString = false;
         $escaped = false;
@@ -139,15 +130,12 @@ class OptimisticJsonParser
         for ($i = 0; $i < \strlen($jsonString); ++$i) {
             $char = $jsonString[$i];
 
-            // Skip characters in strings (except end quotes)
             if ('"' === $char && !$escaped) {
                 $inString = !$inString;
             }
 
-            // Update escape state
             $escaped = '\\' === $char && !$escaped;
 
-            // Only process structural characters when not in a string
             if (!$inString) {
                 if ('[' === $char || '{' === $char) {
                     $stack[] = $char;
@@ -163,7 +151,6 @@ class OptimisticJsonParser
             }
         }
 
-        // Close any unclosed brackets or braces in the correct order
         $result = $jsonString;
         while ([] !== $stack) {
             $openChar = \array_pop($stack);

--- a/packages/chat/tests/Unit/Util/Json/OptimisticJsonParserTest.php
+++ b/packages/chat/tests/Unit/Util/Json/OptimisticJsonParserTest.php
@@ -55,8 +55,24 @@ class OptimisticJsonParserTest extends TestCase
     }
 
     /**
-     * Provider for valid JSON strings.
-     *
+     * @dataProvider edgeCasesProvider
+     */
+    public function testParseWithEdgeCases(string $json, mixed $expectedResult): void
+    {
+        $result = OptimisticJsonParser::parse($json);
+        $this->assertSame($expectedResult, $result);
+    }
+
+    /**
+     * @dataProvider falsyValuesProvider
+     */
+    public function testParseWithFalsyValues(string $json, mixed $expectedResult): void
+    {
+        $result = OptimisticJsonParser::parse($json);
+        $this->assertSame($expectedResult, $result);
+    }
+
+    /**
      * @return array<string, array{0: string, 1: mixed}>
      */
     public static function validJsonProvider(): array
@@ -68,14 +84,14 @@ class OptimisticJsonParserTest extends TestCase
             'simple array' => ['[1,2,3]', [1, 2, 3]],
             'nested object' => ['{"obj":{"key":"value"}}', ['obj' => ['key' => 'value']]],
             'nested array' => ['[1,[2,3],4]', [1, [2, 3], 4]],
-            'complex json' => ['{"name":"John","age":30,"city":"New York","skills":["PHP","JavaScript"]}',
-                ['name' => 'John', 'age' => 30, 'city' => 'New York', 'skills' => ['PHP', 'JavaScript']]],
+            'complex json' => [
+                '{"name":"John","age":30,"city":"New York","skills":["PHP","JavaScript"]}',
+                ['name' => 'John', 'age' => 30, 'city' => 'New York', 'skills' => ['PHP', 'JavaScript']],
+            ],
         ];
     }
 
     /**
-     * Provider for incomplete JSON strings that can be fixed.
-     *
      * @return array<string, array{0: string, 1: mixed}>
      */
     public static function incompleteJsonProvider(): array
@@ -89,12 +105,20 @@ class OptimisticJsonParserTest extends TestCase
             'unclosed nested structures' => ['{"obj":{"key":"value"', ['obj' => ['key' => 'value']]],
             'multiple unclosed objects' => ['{"a":{"b":{"c":"d"', ['a' => ['b' => ['c' => 'd']]]],
             'unclosed array and object' => ['[{"key":"value"', [['key' => 'value']]],
+            'dangling colon' => ['{"key":', ['key' => null]],
+            'dangling colon with space' => ['{"key": ', ['key' => null]],
+            'dangling colon in nested' => ['{"a": {"b":', ['a' => ['b' => null]]],
+            'partial true' => ['{"key": tru', ['key' => true]],
+            'partial false' => ['{"key": fal', ['key' => false]],
+            'partial false fals' => ['{"key": fals', ['key' => false]],
+            'partial null' => ['{"key": nul', ['key' => null]],
+            'partial null nu' => ['{"key": nu', ['key' => null]],
+            'trailing comma at end of object' => ['{"a": 1,', ['a' => 1]],
+            'trailing comma at end of array' => ['[1, 2,', [1, 2]],
         ];
     }
 
     /**
-     * Provider for JSON strings that mimic OpenAI API streaming responses.
-     *
      * @return array<string, array{0: string, 1: mixed}>
      */
     public static function streamedJsonProvider(): array
@@ -159,8 +183,6 @@ class OptimisticJsonParserTest extends TestCase
     }
 
     /**
-     * Provider for invalid JSON strings that cannot be fixed.
-     *
      * @return array<string, array{0: string, 1: mixed}>
      */
     public static function invalidJsonProvider(): array
@@ -168,25 +190,12 @@ class OptimisticJsonParserTest extends TestCase
         return [
             'completely invalid' => ['not json at all', null],
             'malformed json' => ['{"key"::value"}', null],
-            'invalid syntax' => ['{"key":"value"}}}}', null], // Too many closing braces
-            'invalid nesting' => ['{"key":["value"}}', null], // Mismatched brackets and braces
+            'invalid syntax' => ['{"key":"value"}}}}', null],
+            'invalid nesting' => ['{"key":["value"}}', null],
         ];
     }
 
     /**
-     * Test for edge cases like empty strings and null values.
-     *
-     * @dataProvider edgeCasesProvider
-     */
-    public function testParseWithEdgeCases(string $json, mixed $expectedResult): void
-    {
-        $result = OptimisticJsonParser::parse($json);
-        $this->assertSame($expectedResult, $result);
-    }
-
-    /**
-     * Provider for edge cases.
-     *
      * @return array<string, array{0: string, 1: mixed}>
      */
     public static function edgeCasesProvider(): array
@@ -202,8 +211,25 @@ class OptimisticJsonParserTest extends TestCase
     }
 
     /**
-     * Test for quoted strings with escaped quotes inside them.
+     * @return array<string, array{0: string, 1: mixed}>
      */
+    public static function falsyValuesProvider(): array
+    {
+        return [
+            'zero integer' => ['0', 0],
+            'zero float' => ['0.0', 0.0],
+            'false' => ['false', false],
+            'null' => ['null', null],
+            'empty string value' => ['""', ''],
+            'string zero' => ['"0"', '0'],
+            'object with zero' => ['{"a": 0}', ['a' => 0]],
+            'object with false' => ['{"a": false}', ['a' => false]],
+            'object with null' => ['{"a": null}', ['a' => null]],
+            'object with empty string' => ['{"a": ""}', ['a' => '']],
+            'array with falsy values' => ['[0, false, null, ""]', [0, false, null, '']],
+        ];
+    }
+
     public function testParseWithEscapedQuotes(): void
     {
         $json = '{"message":"This is a \"quoted\" string"}';
@@ -213,10 +239,6 @@ class OptimisticJsonParserTest extends TestCase
         $this->assertSame($expectedResult, $result);
     }
 
-    /**
-     * Test for a progressive stream of JSON that gets more complete.
-     * This simulates how a streaming API might deliver chunks.
-     */
     public function testProgressiveJsonStream(): void
     {
         $chunks = [
@@ -231,11 +253,30 @@ class OptimisticJsonParserTest extends TestCase
             $result = OptimisticJsonParser::parse($chunk);
             $this->assertNotNull($result, "Failed to parse chunk $index: $chunk");
 
-            // The last chunk should be fully parseable without optimistic fixes
             if ($index === \count($chunks) - 1) {
                 $standardParse = \json_decode($chunk, true);
                 $this->assertSame($standardParse, $result, 'Last chunk should parse normally');
             }
         }
+    }
+
+    public function testErrorMessagePropagation(): void
+    {
+        $errorMessage = null;
+
+        // Valid JSON should not set error message
+        OptimisticJsonParser::parse('{"key": "value"}', $errorMessage);
+        $this->assertNull($errorMessage);
+
+        // Fixable JSON sets error message from initial parse attempt, then overwrites on successful fix
+        $errorMessage = null;
+        $result = OptimisticJsonParser::parse('{"key": "value"', $errorMessage);
+        $this->assertSame(['key' => 'value'], $result);
+
+        // Unfixable JSON should set error message
+        $errorMessage = null;
+        OptimisticJsonParser::parse('not json at all', $errorMessage);
+        $this->assertNotNull($errorMessage);
+        $this->assertNotEmpty($errorMessage);
     }
 }

--- a/packages/chat/tests/Unit/Util/Json/OptimisticJsonParserTest.php
+++ b/packages/chat/tests/Unit/Util/Json/OptimisticJsonParserTest.php
@@ -268,10 +268,11 @@ class OptimisticJsonParserTest extends TestCase
         OptimisticJsonParser::parse('{"key": "value"}', $errorMessage);
         $this->assertNull($errorMessage);
 
-        // Fixable JSON sets error message from initial parse attempt, then overwrites on successful fix
+        // Successful fix should clear the initial parse error
         $errorMessage = null;
         $result = OptimisticJsonParser::parse('{"key": "value"', $errorMessage);
         $this->assertSame(['key' => 'value'], $result);
+        $this->assertNull($errorMessage);
 
         // Unfixable JSON should set error message
         $errorMessage = null;


### PR DESCRIPTION
Fix $errorMessage propagation from parse() to fixAndParseJson(), add fixIncompleteValues() to handle dangling colons, partial boolean/null literals, and trailing commas in streamed JSON. Remove redundant comments and add tests for falsy values and error message threading.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON parser recovery for malformed input, including normalization of incomplete values (dangling colons, partial booleans/nulls, trailing commas) and more robust structure-closing logic.
  * Ensures parse returns null on unrecoverable input while propagating clear error messages.

* **Tests**
  * Expanded unit coverage with new edge-case and falsy-value scenarios.
  * Added tests to verify error message propagation during parsing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->