### PR TITLE
Add JSON Schema parsing support for tool definitions

### DIFF
--- a/packages/chat/examples/WeatherTool.php
+++ b/packages/chat/examples/WeatherTool.php
@@ -22,10 +22,11 @@ class WeatherTool
      * Get the current weather for a city.
      *
      * @param string $city The city name
+     * @param string|null $unit The temperature unit (celsius or fahrenheit)
      *
      * @return array The weather information
      */
-    public function getCurrentWeather(string $city): array
+    public function getCurrentWeather(string $city, ?string $unit = null): array
     {
         // In a real application, this would make an API call to a weather service
         // For demo purposes, we'll just return some fake data
@@ -53,12 +54,22 @@ class WeatherTool
         // Convert city name to lowercase for case-insensitive lookup
         $cityLower = \strtolower($city);
 
-        // Return data for the requested city, or default data if not found
-        return $weatherData[$cityLower] ?? [
+        // Get data for the requested city, or default data if not found
+        $data = $weatherData[$cityLower] ?? [
             'temperature' => 20,
             'condition' => 'unknown',
             'humidity' => 60,
             'wind_speed' => 8,
         ];
+
+        // Convert temperature to fahrenheit if requested
+        if ('fahrenheit' === $unit) {
+            $data['temperature'] = (int) ($data['temperature'] * 9 / 5 + 32);
+            $data['unit'] = 'fahrenheit';
+        } else {
+            $data['unit'] = 'celsius';
+        }
+
+        return $data;
     }
 }

--- a/packages/chat/phpstan-baseline.neon
+++ b/packages/chat/phpstan-baseline.neon
@@ -67,6 +67,18 @@ parameters:
 			path: src/Response/TokenEstimator.php
 
 		-
+			message: '#^Parameter \#2 \$schema of static method ModelflowAi\\Chat\\ToolInfo\\Parameter\:\:fromJsonSchema\(\) expects array\<string, mixed\>, array\<mixed, mixed\> given\.$#'
+			identifier: argument.type
+			count: 2
+			path: src/ToolInfo/Parameter.php
+
+		-
+			message: '#^Parameter \#2 \$schema of static method ModelflowAi\\Chat\\ToolInfo\\Parameter\:\:fromJsonSchema\(\) expects array\<string, mixed\>, array\<mixed, mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/ToolInfo/ToolInfo.php
+
+		-
 			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) with ''ModelflowAi\\\\Chat\\\\Request\\\\AIChatMessageCollection'' and ModelflowAi\\Chat\\Request\\AIChatMessageCollection will always evaluate to true\.$#'
 			identifier: method.alreadyNarrowedType
 			count: 2
@@ -177,5 +189,5 @@ parameters:
 		-
 			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertSame\(\) with ModelflowAi\\Chat\\ToolInfo\\ToolTypeEnum\:\:FUNCTION and ModelflowAi\\Chat\\ToolInfo\\ToolTypeEnum will always evaluate to true\.$#'
 			identifier: method.alreadyNarrowedType
-			count: 1
+			count: 2
 			path: tests/Unit/ToolInfo/ToolInfoTest.php

--- a/packages/chat/src/ToolInfo/Parameter.php
+++ b/packages/chat/src/ToolInfo/Parameter.php
@@ -23,13 +23,16 @@ namespace ModelflowAi\Chat\ToolInfo;
  *     enum: mixed[],
  *     format: string|null,
  *     itemsOrProperties: mixed[]|string|null,
+ *     nullable: bool,
+ *     required: string[],
  * }
  */
 class Parameter
 {
     /**
      * @param mixed[] $enum
-     * @param mixed[]|string|null $itemsOrProperties
+     * @param Parameter[]|string|null $itemsOrProperties
+     * @param string[] $required
      */
     public function __construct(
         public string $name,
@@ -38,7 +41,144 @@ class Parameter
         public array $enum = [],
         public ?string $format = null,
         public array|string|null $itemsOrProperties = null,
+        public bool $nullable = false,
+        public array $required = [],
     ) {
+    }
+
+    /**
+     * @param array<string, mixed> $schema
+     */
+    public static function fromJsonSchema(string $name, array $schema): self
+    {
+        /** @var mixed $type */
+        $type = $schema['type'] ?? 'string';
+        /** @var mixed $description */
+        $description = $schema['description'] ?? '';
+        $nullable = false;
+
+        // Handle array types like ["string", "null"]
+        if (\is_array($type)) {
+            [$type, $nullable] = self::parseArrayType($type);
+        }
+
+        if (!\is_string($type)) {
+            $type = 'string';
+        }
+
+        if (!\is_string($description)) {
+            $description = '';
+        }
+
+        $itemsOrProperties = null;
+        $enum = [];
+        $format = null;
+        $required = self::parseRequiredArray($schema['required'] ?? null);
+
+        /** @var mixed $properties */
+        $properties = $schema['properties'] ?? null;
+        if ('object' === $type && \is_array($properties)) {
+            $nestedProperties = [];
+            /** @var mixed $nestedSchema */
+            foreach ($properties as $nestedName => $nestedSchema) {
+                if (\is_string($nestedName) && \is_array($nestedSchema)) {
+                    $nestedProperties[] = self::fromJsonSchema($nestedName, $nestedSchema);
+                }
+            }
+            $itemsOrProperties = $nestedProperties;
+        }
+
+        /** @var mixed $items */
+        $items = $schema['items'] ?? null;
+        if ('array' === $type && null !== $items) {
+            if (\is_string($items)) {
+                $itemsOrProperties = $items;
+            } elseif (\is_array($items)) {
+                /** @var mixed $itemsType */
+                $itemsType = $items['type'] ?? 'string';
+                if (\is_array($itemsType)) {
+                    [$itemsType] = self::parseArrayType($itemsType);
+                }
+
+                /** @var mixed $itemProperties */
+                $itemProperties = $items['properties'] ?? null;
+                if ('object' === $itemsType && \is_array($itemProperties)) {
+                    $nestedProperties = [];
+                    /** @var mixed $nestedSchema */
+                    foreach ($itemProperties as $nestedName => $nestedSchema) {
+                        if (\is_string($nestedName) && \is_array($nestedSchema)) {
+                            $nestedProperties[] = self::fromJsonSchema($nestedName, $nestedSchema);
+                        }
+                    }
+                    $itemsOrProperties = $nestedProperties;
+                    $required = self::parseRequiredArray($items['required'] ?? null);
+                } else {
+                    $itemsOrProperties = \is_string($itemsType) ? $itemsType : 'string';
+                }
+            }
+        }
+
+        /** @var mixed $enumValues */
+        $enumValues = $schema['enum'] ?? null;
+        if (\is_array($enumValues)) {
+            $enum = $enumValues;
+        }
+
+        /** @var mixed $formatValue */
+        $formatValue = $schema['format'] ?? null;
+        if (\is_string($formatValue)) {
+            $format = $formatValue;
+        }
+
+        return new self(
+            name: $name,
+            type: $type,
+            description: $description,
+            enum: $enum,
+            format: $format,
+            itemsOrProperties: $itemsOrProperties,
+            nullable: $nullable,
+            required: $required,
+        );
+    }
+
+    /**
+     * @param array<mixed> $types
+     *
+     * @return array{0: string, 1: bool}
+     */
+    private static function parseArrayType(array $types): array
+    {
+        $nullable = \in_array('null', $types, true);
+        $primaryType = 'string';
+
+        foreach ($types as $type) {
+            if (\is_string($type) && 'null' !== $type) {
+                $primaryType = $type;
+                break;
+            }
+        }
+
+        return [$primaryType, $nullable];
+    }
+
+    /**
+     * @return string[]
+     */
+    private static function parseRequiredArray(mixed $required): array
+    {
+        if (!\is_array($required)) {
+            return [];
+        }
+
+        $result = [];
+        foreach ($required as $item) {
+            if (\is_string($item)) {
+                $result[] = $item;
+            }
+        }
+
+        return $result;
     }
 
     /**
@@ -52,7 +192,24 @@ class Parameter
             'description' => $this->description,
             'enum' => $this->enum,
             'format' => $this->format,
-            'itemsOrProperties' => $this->itemsOrProperties,
+            'itemsOrProperties' => $this->serializeItemsOrProperties(),
+            'nullable' => $this->nullable,
+            'required' => $this->required,
         ];
+    }
+
+    /**
+     * @return mixed[]|string|null
+     */
+    private function serializeItemsOrProperties(): array|string|null
+    {
+        if (null === $this->itemsOrProperties || \is_string($this->itemsOrProperties)) {
+            return $this->itemsOrProperties;
+        }
+
+        return \array_map(
+            static fn (Parameter $parameter) => $parameter->toArray(),
+            $this->itemsOrProperties,
+        );
     }
 }

--- a/packages/chat/src/ToolInfo/ToolInfo.php
+++ b/packages/chat/src/ToolInfo/ToolInfo.php
@@ -34,6 +34,72 @@ final readonly class ToolInfo
     }
 
     /**
+     * @param array<string, mixed> $definition
+     */
+    public static function fromJsonSchema(array $definition): self
+    {
+        // Support both OpenAI format (with 'function' wrapper) and direct format
+        /** @var mixed $function */
+        $function = $definition['function'] ?? $definition;
+
+        if (!\is_array($function)) {
+            throw new \InvalidArgumentException('Tool definition must contain a function definition');
+        }
+
+        /** @var mixed $name */
+        $name = $function['name'] ?? null;
+        /** @var mixed $description */
+        $description = $function['description'] ?? '';
+
+        if (!\is_string($name)) {
+            throw new \InvalidArgumentException('Tool function must have a name');
+        }
+
+        if (!\is_string($description)) {
+            $description = '';
+        }
+
+        /** @var mixed $paramsSchema */
+        $paramsSchema = $function['parameters'] ?? [];
+        $parameters = [];
+        $requiredParams = [];
+        /** @var array<string> $requiredNames */
+        $requiredNames = [];
+
+        if (\is_array($paramsSchema)) {
+            /** @var mixed $required */
+            $required = $paramsSchema['required'] ?? [];
+            $requiredNames = \is_array($required) ? $required : [];
+
+            /** @var mixed $properties */
+            $properties = $paramsSchema['properties'] ?? null;
+            if (\is_array($properties)) {
+                /** @var mixed $paramSchema */
+                foreach ($properties as $paramName => $paramSchema) {
+                    if (!\is_string($paramName) || !\is_array($paramSchema)) {
+                        continue;
+                    }
+
+                    $parameter = Parameter::fromJsonSchema($paramName, $paramSchema);
+                    $parameters[] = $parameter;
+
+                    if (\in_array($paramName, $requiredNames, true)) {
+                        $requiredParams[] = $parameter;
+                    }
+                }
+            }
+        }
+
+        return new self(
+            type: ToolTypeEnum::FUNCTION,
+            name: $name,
+            description: $description,
+            parameters: $parameters,
+            requiredParameters: $requiredParams,
+        );
+    }
+
+    /**
      * @return array{
      *     type: string,
      *     name: string,

--- a/packages/chat/src/ToolInfo/ToolInfoBuilder.php
+++ b/packages/chat/src/ToolInfo/ToolInfoBuilder.php
@@ -39,9 +39,10 @@ class ToolInfoBuilder
             \preg_match(\sprintf('/\* @param [^\$]* \$%s (?<description>.*)/', $param->getName()), $docComment, $matches);
 
             $newParameter = new Parameter(
-                $param->getName(),
-                Types::mapPhpTypeToJsonSchemaType($reflectionType),
-                $matches['description'] ?? '',
+                name: $param->getName(),
+                type: Types::mapPhpTypeToJsonSchemaType($reflectionType),
+                description: $matches['description'] ?? '',
+                nullable: $reflectionType->allowsNull(),
             );
 
             if ('array' === $newParameter->type) {

--- a/packages/chat/tests/Unit/ToolInfo/ParameterTest.php
+++ b/packages/chat/tests/Unit/ToolInfo/ParameterTest.php
@@ -60,9 +60,16 @@ class ParameterTest extends TestCase
         $this->assertSame('TEST', $message->itemsOrProperties);
     }
 
+    public function testNullable(): void
+    {
+        $parameter = new Parameter('name', 'string', 'Test description', [], null, null, true);
+
+        $this->assertTrue($parameter->nullable);
+    }
+
     public function testToArray(): void
     {
-        $message = new Parameter('name', 'string', 'Test description', ['t1', 't2'], 'json', 'TEST');
+        $message = new Parameter('name', 'string', 'Test description', ['t1', 't2'], 'json', 'TEST', true);
 
         $this->assertSame([
             'name' => 'name',
@@ -71,6 +78,290 @@ class ParameterTest extends TestCase
             'enum' => ['t1', 't2'],
             'format' => 'json',
             'itemsOrProperties' => 'TEST',
+            'nullable' => true,
+            'required' => [],
         ], $message->toArray());
+    }
+
+    public function testFromJsonSchemaSimple(): void
+    {
+        $parameter = Parameter::fromJsonSchema('username', [
+            'type' => 'string',
+            'description' => 'The username',
+        ]);
+
+        $this->assertSame('username', $parameter->name);
+        $this->assertSame('string', $parameter->type);
+        $this->assertSame('The username', $parameter->description);
+        $this->assertFalse($parameter->nullable);
+    }
+
+    public function testFromJsonSchemaNullableType(): void
+    {
+        $parameter = Parameter::fromJsonSchema('email', [
+            'type' => ['string', 'null'],
+            'description' => 'Optional email',
+        ]);
+
+        $this->assertSame('email', $parameter->name);
+        $this->assertSame('string', $parameter->type);
+        $this->assertSame('Optional email', $parameter->description);
+        $this->assertTrue($parameter->nullable);
+    }
+
+    public function testFromJsonSchemaWithEnum(): void
+    {
+        $parameter = Parameter::fromJsonSchema('status', [
+            'type' => 'string',
+            'description' => 'The status',
+            'enum' => ['active', 'inactive', 'pending'],
+        ]);
+
+        $this->assertSame('status', $parameter->name);
+        $this->assertSame('string', $parameter->type);
+        $this->assertSame(['active', 'inactive', 'pending'], $parameter->enum);
+    }
+
+    public function testFromJsonSchemaWithFormat(): void
+    {
+        $parameter = Parameter::fromJsonSchema('created_at', [
+            'type' => 'string',
+            'description' => 'Creation date',
+            'format' => 'date-time',
+        ]);
+
+        $this->assertSame('created_at', $parameter->name);
+        $this->assertSame('date-time', $parameter->format);
+    }
+
+    public function testFromJsonSchemaObjectType(): void
+    {
+        $parameter = Parameter::fromJsonSchema('context', [
+            'type' => 'object',
+            'description' => 'Context object',
+            'properties' => [
+                'chipNumber' => [
+                    'type' => ['string', 'null'],
+                    'description' => 'The chip number',
+                ],
+                'hasSketch' => [
+                    'type' => ['boolean', 'null'],
+                    'description' => 'Whether has sketch',
+                ],
+            ],
+        ]);
+
+        $this->assertSame('context', $parameter->name);
+        $this->assertSame('object', $parameter->type);
+        $this->assertIsArray($parameter->itemsOrProperties);
+        $this->assertCount(2, $parameter->itemsOrProperties);
+
+        /** @var Parameter $chipNumber */
+        $chipNumber = $parameter->itemsOrProperties[0];
+        $this->assertSame('chipNumber', $chipNumber->name);
+        $this->assertSame('string', $chipNumber->type);
+        $this->assertTrue($chipNumber->nullable);
+
+        /** @var Parameter $hasSketch */
+        $hasSketch = $parameter->itemsOrProperties[1];
+        $this->assertSame('hasSketch', $hasSketch->name);
+        $this->assertSame('boolean', $hasSketch->type);
+        $this->assertTrue($hasSketch->nullable);
+    }
+
+    public function testFromJsonSchemaArrayOfStrings(): void
+    {
+        $parameter = Parameter::fromJsonSchema('tags', [
+            'type' => 'array',
+            'description' => 'List of tags',
+            'items' => [
+                'type' => 'string',
+            ],
+        ]);
+
+        $this->assertSame('tags', $parameter->name);
+        $this->assertSame('array', $parameter->type);
+        $this->assertSame('string', $parameter->itemsOrProperties);
+    }
+
+    public function testFromJsonSchemaArrayOfObjects(): void
+    {
+        $parameter = Parameter::fromJsonSchema('items', [
+            'type' => 'array',
+            'description' => 'List of items',
+            'items' => [
+                'type' => 'object',
+                'properties' => [
+                    'id' => [
+                        'type' => 'integer',
+                        'description' => 'Item ID',
+                    ],
+                    'name' => [
+                        'type' => 'string',
+                        'description' => 'Item name',
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertSame('items', $parameter->name);
+        $this->assertSame('array', $parameter->type);
+        $this->assertIsArray($parameter->itemsOrProperties);
+        $this->assertCount(2, $parameter->itemsOrProperties);
+
+        /** @var Parameter $id */
+        $id = $parameter->itemsOrProperties[0];
+        $this->assertSame('id', $id->name);
+        $this->assertSame('integer', $id->type);
+
+        /** @var Parameter $name */
+        $name = $parameter->itemsOrProperties[1];
+        $this->assertSame('name', $name->name);
+        $this->assertSame('string', $name->type);
+    }
+
+    public function testFromJsonSchemaDefaults(): void
+    {
+        $parameter = Parameter::fromJsonSchema('empty', []);
+
+        $this->assertSame('empty', $parameter->name);
+        $this->assertSame('string', $parameter->type);
+        $this->assertSame('', $parameter->description);
+        $this->assertFalse($parameter->nullable);
+    }
+
+    public function testRequired(): void
+    {
+        $parameter = new Parameter('name', 'object', 'Test', [], null, null, false, ['field1', 'field2']);
+
+        $this->assertSame(['field1', 'field2'], $parameter->required);
+    }
+
+    public function testFromJsonSchemaObjectWithRequired(): void
+    {
+        $parameter = Parameter::fromJsonSchema('user', [
+            'type' => 'object',
+            'description' => 'User object',
+            'properties' => [
+                'id' => [
+                    'type' => 'integer',
+                    'description' => 'User ID',
+                ],
+                'name' => [
+                    'type' => 'string',
+                    'description' => 'User name',
+                ],
+                'email' => [
+                    'type' => 'string',
+                    'description' => 'User email',
+                ],
+            ],
+            'required' => ['id', 'name'],
+        ]);
+
+        $this->assertSame('user', $parameter->name);
+        $this->assertSame('object', $parameter->type);
+        $this->assertSame(['id', 'name'], $parameter->required);
+        $this->assertIsArray($parameter->itemsOrProperties);
+        $this->assertCount(3, $parameter->itemsOrProperties);
+    }
+
+    public function testFromJsonSchemaArrayOfObjectsWithRequired(): void
+    {
+        $parameter = Parameter::fromJsonSchema('items', [
+            'type' => 'array',
+            'description' => 'List of items',
+            'items' => [
+                'type' => 'object',
+                'properties' => [
+                    'id' => [
+                        'type' => 'integer',
+                        'description' => 'Item ID',
+                    ],
+                    'name' => [
+                        'type' => 'string',
+                        'description' => 'Item name',
+                    ],
+                    'optional' => [
+                        'type' => 'string',
+                        'description' => 'Optional field',
+                    ],
+                ],
+                'required' => ['id', 'name'],
+            ],
+        ]);
+
+        $this->assertSame('items', $parameter->name);
+        $this->assertSame('array', $parameter->type);
+        $this->assertSame(['id', 'name'], $parameter->required);
+        $this->assertIsArray($parameter->itemsOrProperties);
+        $this->assertCount(3, $parameter->itemsOrProperties);
+    }
+
+    public function testFromJsonSchemaRequiredWithInvalidItems(): void
+    {
+        $parameter = Parameter::fromJsonSchema('test', [
+            'type' => 'object',
+            'required' => ['valid', 123, null, 'another'],
+        ]);
+
+        $this->assertSame(['valid', 'another'], $parameter->required);
+    }
+
+    public function testFromJsonSchemaRequiredNotArray(): void
+    {
+        $parameter = Parameter::fromJsonSchema('test', [
+            'type' => 'object',
+            'required' => 'invalid',
+        ]);
+
+        $this->assertSame([], $parameter->required);
+    }
+
+    public function testToArrayWithNestedParameters(): void
+    {
+        $nestedProperties = [
+            new Parameter('id', 'integer', 'The ID'),
+            new Parameter('name', 'string', 'The name'),
+        ];
+
+        $parameter = new Parameter(
+            name: 'user',
+            type: 'object',
+            description: 'User object',
+            itemsOrProperties: $nestedProperties,
+            required: ['id'],
+        );
+
+        $array = $parameter->toArray();
+
+        $this->assertSame('user', $array['name']);
+        $this->assertSame('object', $array['type']);
+        $this->assertIsArray($array['itemsOrProperties']);
+        $this->assertCount(2, $array['itemsOrProperties']);
+
+        // Verify nested Parameters are serialized to arrays
+        $this->assertIsArray($array['itemsOrProperties'][0]);
+        $this->assertSame('id', $array['itemsOrProperties'][0]['name']);
+        $this->assertSame('integer', $array['itemsOrProperties'][0]['type']);
+
+        $this->assertIsArray($array['itemsOrProperties'][1]);
+        $this->assertSame('name', $array['itemsOrProperties'][1]['name']);
+        $this->assertSame('string', $array['itemsOrProperties'][1]['type']);
+    }
+
+    public function testToArrayWithStringItemsOrProperties(): void
+    {
+        $parameter = new Parameter(
+            name: 'tags',
+            type: 'array',
+            description: 'List of tags',
+            itemsOrProperties: 'string',
+        );
+
+        $array = $parameter->toArray();
+
+        $this->assertSame('tags', $array['name']);
+        $this->assertSame('string', $array['itemsOrProperties']);
     }
 }

--- a/packages/chat/tests/Unit/ToolInfo/ToolInfoBuilderTest.php
+++ b/packages/chat/tests/Unit/ToolInfo/ToolInfoBuilderTest.php
@@ -36,6 +36,20 @@ class ToolInfoBuilderTest extends TestCase
         $this->assertSame('this is a required parameter', $toolInfo->parameters[0]->description);
     }
 
+    public function testBuildToolInfoWithNullableParameter(): void
+    {
+        $toolInfo = ToolInfoBuilder::buildToolInfo($this, 'toolMethodWithNullable', 'test_nullable', ToolTypeEnum::FUNCTION);
+
+        $this->assertSame('test_nullable', $toolInfo->name);
+        $this->assertCount(2, $toolInfo->parameters);
+
+        $this->assertSame('city', $toolInfo->parameters[0]->name);
+        $this->assertFalse($toolInfo->parameters[0]->nullable);
+
+        $this->assertSame('unit', $toolInfo->parameters[1]->name);
+        $this->assertTrue($toolInfo->parameters[1]->nullable);
+    }
+
     /**
      * This is a description.
      *
@@ -45,5 +59,18 @@ class ToolInfoBuilderTest extends TestCase
     public function toolMethod(string $required, string $optional = ''): string
     {
         return $required . $optional;
+    }
+
+    /**
+     * Get weather for a city.
+     *
+     * @param string $city The city name
+     * @param string|null $unit The temperature unit
+     *
+     * @return array<string, string|null>
+     */
+    public function toolMethodWithNullable(string $city, ?string $unit = null): array
+    {
+        return ['city' => $city, 'unit' => $unit];
     }
 }

--- a/packages/chat/tests/Unit/ToolInfo/ToolInfoTest.php
+++ b/packages/chat/tests/Unit/ToolInfo/ToolInfoTest.php
@@ -86,6 +86,8 @@ class ToolInfoTest extends TestCase
                     'enum' => [],
                     'format' => null,
                     'itemsOrProperties' => null,
+                    'nullable' => false,
+                    'required' => [],
                 ],
                 [
                     'name' => 'name2',
@@ -94,6 +96,8 @@ class ToolInfoTest extends TestCase
                     'enum' => [],
                     'format' => null,
                     'itemsOrProperties' => null,
+                    'nullable' => false,
+                    'required' => [],
                 ],
             ],
             'requiredParameters' => [
@@ -104,8 +108,162 @@ class ToolInfoTest extends TestCase
                     'enum' => [],
                     'format' => null,
                     'itemsOrProperties' => null,
+                    'nullable' => false,
+                    'required' => [],
                 ],
             ],
         ], $message->toArray());
+    }
+
+    public function testFromJsonSchemaOpenAiFormat(): void
+    {
+        $toolInfo = ToolInfo::fromJsonSchema([
+            'type' => 'function',
+            'function' => [
+                'name' => 'get_weather',
+                'description' => 'Get the current weather',
+                'parameters' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'location' => [
+                            'type' => 'string',
+                            'description' => 'The city and country',
+                        ],
+                        'unit' => [
+                            'type' => 'string',
+                            'description' => 'Temperature unit',
+                            'enum' => ['celsius', 'fahrenheit'],
+                        ],
+                    ],
+                    'required' => ['location'],
+                ],
+            ],
+        ]);
+
+        $this->assertSame(ToolTypeEnum::FUNCTION, $toolInfo->type);
+        $this->assertSame('get_weather', $toolInfo->name);
+        $this->assertSame('Get the current weather', $toolInfo->description);
+        $this->assertCount(2, $toolInfo->parameters);
+        $this->assertCount(1, $toolInfo->requiredParameters);
+
+        $this->assertSame('location', $toolInfo->parameters[0]->name);
+        $this->assertSame('string', $toolInfo->parameters[0]->type);
+
+        $this->assertSame('unit', $toolInfo->parameters[1]->name);
+        $this->assertSame(['celsius', 'fahrenheit'], $toolInfo->parameters[1]->enum);
+
+        $this->assertSame('location', $toolInfo->requiredParameters[0]->name);
+    }
+
+    public function testFromJsonSchemaDirectFormat(): void
+    {
+        $toolInfo = ToolInfo::fromJsonSchema([
+            'name' => 'calculator',
+            'description' => 'Perform calculations',
+            'parameters' => [
+                'type' => 'object',
+                'properties' => [
+                    'expression' => [
+                        'type' => 'string',
+                        'description' => 'The math expression',
+                    ],
+                ],
+                'required' => ['expression'],
+            ],
+        ]);
+
+        $this->assertSame('calculator', $toolInfo->name);
+        $this->assertSame('Perform calculations', $toolInfo->description);
+        $this->assertCount(1, $toolInfo->parameters);
+        $this->assertCount(1, $toolInfo->requiredParameters);
+    }
+
+    public function testFromJsonSchemaWithNestedObject(): void
+    {
+        $toolInfo = ToolInfo::fromJsonSchema([
+            'type' => 'function',
+            'function' => [
+                'name' => 'passport_control',
+                'description' => 'Control passport status',
+                'parameters' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'horseName' => [
+                            'type' => 'string',
+                            'description' => 'Name of the horse',
+                        ],
+                        'context' => [
+                            'type' => 'object',
+                            'description' => 'Context data',
+                            'properties' => [
+                                'chipNumber' => [
+                                    'type' => ['string', 'null'],
+                                    'description' => 'The chip number',
+                                ],
+                                'hasSketch' => [
+                                    'type' => ['boolean', 'null'],
+                                    'description' => 'Has sketch',
+                                ],
+                            ],
+                        ],
+                    ],
+                    'required' => ['horseName', 'context'],
+                ],
+            ],
+        ]);
+
+        $this->assertSame('passport_control', $toolInfo->name);
+        $this->assertCount(2, $toolInfo->parameters);
+        $this->assertCount(2, $toolInfo->requiredParameters);
+
+        $horseName = $toolInfo->parameters[0];
+        $this->assertSame('horseName', $horseName->name);
+        $this->assertSame('string', $horseName->type);
+
+        $context = $toolInfo->parameters[1];
+        $this->assertSame('context', $context->name);
+        $this->assertSame('object', $context->type);
+        $this->assertIsArray($context->itemsOrProperties);
+        $this->assertCount(2, $context->itemsOrProperties);
+
+        /** @var Parameter $chipNumber */
+        $chipNumber = $context->itemsOrProperties[0];
+        $this->assertSame('chipNumber', $chipNumber->name);
+        $this->assertSame('string', $chipNumber->type);
+        $this->assertTrue($chipNumber->nullable);
+
+        /** @var Parameter $hasSketch */
+        $hasSketch = $context->itemsOrProperties[1];
+        $this->assertSame('hasSketch', $hasSketch->name);
+        $this->assertSame('boolean', $hasSketch->type);
+        $this->assertTrue($hasSketch->nullable);
+    }
+
+    public function testFromJsonSchemaWithoutParameters(): void
+    {
+        $toolInfo = ToolInfo::fromJsonSchema([
+            'type' => 'function',
+            'function' => [
+                'name' => 'get_time',
+                'description' => 'Get current time',
+            ],
+        ]);
+
+        $this->assertSame('get_time', $toolInfo->name);
+        $this->assertCount(0, $toolInfo->parameters);
+        $this->assertCount(0, $toolInfo->requiredParameters);
+    }
+
+    public function testFromJsonSchemaThrowsOnMissingName(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Tool function must have a name');
+
+        ToolInfo::fromJsonSchema([
+            'type' => 'function',
+            'function' => [
+                'description' => 'Missing name',
+            ],
+        ]);
     }
 }

--- a/packages/fireworksai-adapter/composer.lock
+++ b/packages/fireworksai-adapter/composer.lock
@@ -1147,7 +1147,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../chat",
-                "reference": "0c62dbd239bd56014c53e05c96d985e63de69bdc"
+                "reference": "dbf738ea4388be5e3291deef3a3f61545132f123"
             },
             "require": {
                 "ext-fileinfo": "*",
@@ -1161,7 +1161,7 @@
                 "jangregor/phpstan-prophecy": "^2.0",
                 "modelflow-ai/prompt-template": "^0.4",
                 "php-cs-fixer/shim": "^3.15",
-                "phpspec/prophecy-phpunit": "^2.1@stable",
+                "phpspec/prophecy-phpunit": "^2.2",
                 "phpstan/extension-installer": "^1.2",
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
@@ -5566,5 +5566,5 @@
         "php": "^8.2"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/packages/fireworksai-adapter/src/Chat/ToolFormatter.php
+++ b/packages/fireworksai-adapter/src/Chat/ToolFormatter.php
@@ -84,26 +84,25 @@ final class ToolFormatter
      * @throws \Exception
      *
      * @return array{
-     *     type: string,
+     *     type: string|string[],
      *     description: string,
      *     items?: array{
-     *         type: string,
-     *         properties?: array<string, array{
-     *             type: string, description: string,
-     *         }>
+     *         type: string|string[],
+     *         properties?: array<string, mixed>,
+     *         required?: string[],
      *     },
-     *     properties?: array<string, array{
-     *         type: string,
-     *          description: string,
-     *     }>,
+     *     properties?: array<string, mixed>,
+     *     required?: string[],
      *     enum?: mixed[],
      *     format?: string,
      * }
      */
     private static function formatParameter(Parameter $parameter): array
     {
+        $type = $parameter->nullable ? [$parameter->type, 'null'] : $parameter->type;
+
         $param = [
-            'type' => $parameter->type,
+            'type' => $type,
             'description' => $parameter->description,
         ];
 
@@ -120,16 +119,19 @@ final class ToolFormatter
                 $properties = [];
                 /** @var Parameter $property */
                 foreach ($parameter->itemsOrProperties as $property) {
-                    $properties[$property->name] = [
-                        'type' => $property->type,
-                        'description' => $property->description,
-                    ];
+                    $properties[$property->name] = self::formatParameter($property);
                 }
 
-                $param['items'] = [
+                $items = [
                     'type' => 'object',
                     'properties' => $properties,
                 ];
+
+                if ([] !== $parameter->required) {
+                    $items['required'] = $parameter->required;
+                }
+
+                $param['items'] = $items;
             }
         }
 
@@ -141,13 +143,14 @@ final class ToolFormatter
             $properties = [];
             /** @var Parameter $item */
             foreach ($parameter->itemsOrProperties as $item) {
-                $properties[$item->name] = [
-                    'type' => $item->type,
-                    'description' => $item->description,
-                ];
+                $properties[$item->name] = self::formatParameter($item);
             }
 
             $param['properties'] = $properties;
+
+            if ([] !== $parameter->required) {
+                $param['required'] = $parameter->required;
+            }
         }
 
         if ($parameter->enum) {

--- a/packages/fireworksai-adapter/tests/Unit/Chat/ToolFormatterTest.php
+++ b/packages/fireworksai-adapter/tests/Unit/Chat/ToolFormatterTest.php
@@ -13,7 +13,10 @@ declare(strict_types=1);
 
 namespace ModelflowAi\FireworksAiAdapter\Tests\Unit\Chat;
 
+use ModelflowAi\Chat\ToolInfo\Parameter;
+use ModelflowAi\Chat\ToolInfo\ToolInfo;
 use ModelflowAi\Chat\ToolInfo\ToolInfoBuilder;
+use ModelflowAi\Chat\ToolInfo\ToolTypeEnum;
 use ModelflowAi\FireworksAiAdapter\Chat\ToolFormatter;
 use PHPUnit\Framework\TestCase;
 
@@ -115,5 +118,62 @@ class ToolFormatterTest extends TestCase
 
     public function toolMethod2(string $test): void
     {
+    }
+
+    public function testFormatToolWithNestedObjectRequired(): void
+    {
+        $nestedProperties = [
+            new Parameter('id', 'integer', 'The ID'),
+            new Parameter('name', 'string', 'The name'),
+        ];
+
+        $objectParam = new Parameter(
+            name: 'user',
+            type: 'object',
+            description: 'User object',
+            itemsOrProperties: $nestedProperties,
+            required: ['id', 'name'],
+        );
+
+        $tool = new ToolInfo(
+            type: ToolTypeEnum::FUNCTION,
+            name: 'create_user',
+            description: 'Create a user',
+            parameters: [$objectParam],
+            requiredParameters: [$objectParam],
+        );
+
+        $formatted = ToolFormatter::formatTool($tool);
+
+        $this->assertSame(['id', 'name'], $formatted['parameters']['properties']['user']['required']);
+    }
+
+    public function testFormatToolWithArrayOfObjectsRequired(): void
+    {
+        $nestedProperties = [
+            new Parameter('id', 'integer', 'Item ID'),
+        ];
+
+        $arrayParam = new Parameter(
+            name: 'items',
+            type: 'array',
+            description: 'List of items',
+            itemsOrProperties: $nestedProperties,
+            required: ['id'],
+        );
+
+        $tool = new ToolInfo(
+            type: ToolTypeEnum::FUNCTION,
+            name: 'process_items',
+            description: 'Process items',
+            parameters: [$arrayParam],
+            requiredParameters: [],
+        );
+
+        $formatted = ToolFormatter::formatTool($tool);
+
+        /** @var array{items: array{required: string[]}} $itemsParam */
+        $itemsParam = $formatted['parameters']['properties']['items'];
+        $this->assertSame(['id'], $itemsParam['items']['required']);
     }
 }

--- a/packages/mistral-adapter/composer.lock
+++ b/packages/mistral-adapter/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "06f71d1577f46819a9e5fef5ab9dd076",
+    "content-hash": "c0175f4618ecebf26f3a38c6a3d64d38",
     "packages": [
         {
             "name": "modelflow-ai/api-client",
@@ -931,7 +931,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../chat",
-                "reference": "0c62dbd239bd56014c53e05c96d985e63de69bdc"
+                "reference": "dbf738ea4388be5e3291deef3a3f61545132f123"
             },
             "require": {
                 "ext-fileinfo": "*",
@@ -945,7 +945,7 @@
                 "jangregor/phpstan-prophecy": "^2.0",
                 "modelflow-ai/prompt-template": "^0.4",
                 "php-cs-fixer/shim": "^3.15",
-                "phpspec/prophecy-phpunit": "^2.1@stable",
+                "phpspec/prophecy-phpunit": "^2.2",
                 "phpstan/extension-installer": "^1.2",
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
@@ -4970,14 +4970,12 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {
-        "phpspec/prophecy-phpunit": 0
-    },
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": "^8.2"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/packages/mistral-adapter/src/Chat/ToolFormatter.php
+++ b/packages/mistral-adapter/src/Chat/ToolFormatter.php
@@ -84,26 +84,25 @@ final class ToolFormatter
      * @throws \Exception
      *
      * @return array{
-     *     type: string,
+     *     type: string|string[],
      *     description: string,
      *     items?: array{
-     *         type: string,
-     *         properties?: array<string, array{
-     *             type: string, description: string,
-     *         }>
+     *         type: string|string[],
+     *         properties?: array<string, mixed>,
+     *         required?: string[],
      *     },
-     *     properties?: array<string, array{
-     *         type: string,
-     *          description: string,
-     *     }>,
+     *     properties?: array<string, mixed>,
+     *     required?: string[],
      *     enum?: mixed[],
      *     format?: string,
      * }
      */
     private static function formatParameter(Parameter $parameter): array
     {
+        $type = $parameter->nullable ? [$parameter->type, 'null'] : $parameter->type;
+
         $param = [
-            'type' => $parameter->type,
+            'type' => $type,
             'description' => $parameter->description,
         ];
 
@@ -120,16 +119,19 @@ final class ToolFormatter
                 $properties = [];
                 /** @var Parameter $property */
                 foreach ($parameter->itemsOrProperties as $property) {
-                    $properties[$property->name] = [
-                        'type' => $property->type,
-                        'description' => $property->description,
-                    ];
+                    $properties[$property->name] = self::formatParameter($property);
                 }
 
-                $param['items'] = [
+                $items = [
                     'type' => 'object',
                     'properties' => $properties,
                 ];
+
+                if ([] !== $parameter->required) {
+                    $items['required'] = $parameter->required;
+                }
+
+                $param['items'] = $items;
             }
         }
 
@@ -141,13 +143,14 @@ final class ToolFormatter
             $properties = [];
             /** @var Parameter $item */
             foreach ($parameter->itemsOrProperties as $item) {
-                $properties[$item->name] = [
-                    'type' => $item->type,
-                    'description' => $item->description,
-                ];
+                $properties[$item->name] = self::formatParameter($item);
             }
 
             $param['properties'] = $properties;
+
+            if ([] !== $parameter->required) {
+                $param['required'] = $parameter->required;
+            }
         }
 
         if ($parameter->enum) {

--- a/packages/mistral-adapter/tests/Unit/Chat/ToolFormatterTest.php
+++ b/packages/mistral-adapter/tests/Unit/Chat/ToolFormatterTest.php
@@ -13,7 +13,10 @@ declare(strict_types=1);
 
 namespace ModelflowAi\MistralAdapter\Tests\Unit\Chat;
 
+use ModelflowAi\Chat\ToolInfo\Parameter;
+use ModelflowAi\Chat\ToolInfo\ToolInfo;
 use ModelflowAi\Chat\ToolInfo\ToolInfoBuilder;
+use ModelflowAi\Chat\ToolInfo\ToolTypeEnum;
 use ModelflowAi\MistralAdapter\Chat\ToolFormatter;
 use PHPUnit\Framework\TestCase;
 
@@ -115,5 +118,62 @@ class ToolFormatterTest extends TestCase
 
     public function toolMethod2(string $test): void
     {
+    }
+
+    public function testFormatToolWithNestedObjectRequired(): void
+    {
+        $nestedProperties = [
+            new Parameter('id', 'integer', 'The ID'),
+            new Parameter('name', 'string', 'The name'),
+        ];
+
+        $objectParam = new Parameter(
+            name: 'user',
+            type: 'object',
+            description: 'User object',
+            itemsOrProperties: $nestedProperties,
+            required: ['id', 'name'],
+        );
+
+        $tool = new ToolInfo(
+            type: ToolTypeEnum::FUNCTION,
+            name: 'create_user',
+            description: 'Create a user',
+            parameters: [$objectParam],
+            requiredParameters: [$objectParam],
+        );
+
+        $formatted = ToolFormatter::formatTool($tool);
+
+        $this->assertSame(['id', 'name'], $formatted['parameters']['properties']['user']['required']);
+    }
+
+    public function testFormatToolWithArrayOfObjectsRequired(): void
+    {
+        $nestedProperties = [
+            new Parameter('id', 'integer', 'Item ID'),
+        ];
+
+        $arrayParam = new Parameter(
+            name: 'items',
+            type: 'array',
+            description: 'List of items',
+            itemsOrProperties: $nestedProperties,
+            required: ['id'],
+        );
+
+        $tool = new ToolInfo(
+            type: ToolTypeEnum::FUNCTION,
+            name: 'process_items',
+            description: 'Process items',
+            parameters: [$arrayParam],
+            requiredParameters: [],
+        );
+
+        $formatted = ToolFormatter::formatTool($tool);
+
+        /** @var array{items: array{required: string[]}} $itemsParam */
+        $itemsParam = $formatted['parameters']['properties']['items'];
+        $this->assertSame(['id'], $itemsParam['items']['required']);
     }
 }

--- a/packages/openai-adapter/composer.lock
+++ b/packages/openai-adapter/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4795f0942555a980736483d68bcd7ca9",
+    "content-hash": "3f5a254db82a50c11ffa1538cef3f6ef",
     "packages": [
         {
             "name": "nyholm/psr7",
@@ -1147,7 +1147,7 @@
             "dist": {
                 "type": "path",
                 "url": "./../chat",
-                "reference": "0c62dbd239bd56014c53e05c96d985e63de69bdc"
+                "reference": "dbf738ea4388be5e3291deef3a3f61545132f123"
             },
             "require": {
                 "ext-fileinfo": "*",
@@ -1161,7 +1161,7 @@
                 "jangregor/phpstan-prophecy": "^2.0",
                 "modelflow-ai/prompt-template": "^0.4",
                 "php-cs-fixer/shim": "^3.15",
-                "phpspec/prophecy-phpunit": "^2.1@stable",
+                "phpspec/prophecy-phpunit": "^2.2",
                 "phpstan/extension-installer": "^1.2",
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
@@ -5452,8 +5452,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "phpspec/prophecy": 20,
-        "phpspec/prophecy-phpunit": 0
+        "phpspec/prophecy": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,
@@ -5461,5 +5460,5 @@
         "php": "^8.2"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/packages/openai-adapter/src/Chat/ToolFormatter.php
+++ b/packages/openai-adapter/src/Chat/ToolFormatter.php
@@ -84,26 +84,25 @@ final class ToolFormatter
      * @throws \Exception
      *
      * @return array{
-     *     type: string,
+     *     type: string|string[],
      *     description: string,
      *     items?: array{
-     *         type: string,
-     *         properties?: array<string, array{
-     *             type: string, description: string,
-     *         }>
+     *         type: string|string[],
+     *         properties?: array<string, mixed>,
+     *         required?: string[],
      *     },
-     *     properties?: array<string, array{
-     *         type: string,
-     *          description: string,
-     *     }>,
+     *     properties?: array<string, mixed>,
+     *     required?: string[],
      *     enum?: mixed[],
      *     format?: string,
      * }
      */
     private static function formatParameter(Parameter $parameter): array
     {
+        $type = $parameter->nullable ? [$parameter->type, 'null'] : $parameter->type;
+
         $param = [
-            'type' => $parameter->type,
+            'type' => $type,
             'description' => $parameter->description,
         ];
 
@@ -120,16 +119,19 @@ final class ToolFormatter
                 $properties = [];
                 /** @var Parameter $property */
                 foreach ($parameter->itemsOrProperties as $property) {
-                    $properties[$property->name] = [
-                        'type' => $property->type,
-                        'description' => $property->description,
-                    ];
+                    $properties[$property->name] = self::formatParameter($property);
                 }
 
-                $param['items'] = [
+                $items = [
                     'type' => 'object',
                     'properties' => $properties,
                 ];
+
+                if ([] !== $parameter->required) {
+                    $items['required'] = $parameter->required;
+                }
+
+                $param['items'] = $items;
             }
         }
 
@@ -141,13 +143,14 @@ final class ToolFormatter
             $properties = [];
             /** @var Parameter $item */
             foreach ($parameter->itemsOrProperties as $item) {
-                $properties[$item->name] = [
-                    'type' => $item->type,
-                    'description' => $item->description,
-                ];
+                $properties[$item->name] = self::formatParameter($item);
             }
 
             $param['properties'] = $properties;
+
+            if ([] !== $parameter->required) {
+                $param['required'] = $parameter->required;
+            }
         }
 
         if ($parameter->enum) {

--- a/packages/openai-adapter/tests/Unit/Chat/ToolFormatterTest.php
+++ b/packages/openai-adapter/tests/Unit/Chat/ToolFormatterTest.php
@@ -13,7 +13,10 @@ declare(strict_types=1);
 
 namespace ModelflowAi\OpenaiAdapter\Tests\Unit\Chat;
 
+use ModelflowAi\Chat\ToolInfo\Parameter;
+use ModelflowAi\Chat\ToolInfo\ToolInfo;
 use ModelflowAi\Chat\ToolInfo\ToolInfoBuilder;
+use ModelflowAi\Chat\ToolInfo\ToolTypeEnum;
 use ModelflowAi\OpenaiAdapter\Chat\ToolFormatter;
 use PHPUnit\Framework\TestCase;
 
@@ -115,5 +118,144 @@ class ToolFormatterTest extends TestCase
 
     public function toolMethod2(string $test): void
     {
+    }
+
+    public function testFormatToolWithNestedObjectRequired(): void
+    {
+        $nestedProperties = [
+            new Parameter('id', 'integer', 'The ID'),
+            new Parameter('name', 'string', 'The name'),
+            new Parameter('optional', 'string', 'Optional field'),
+        ];
+
+        $objectParam = new Parameter(
+            name: 'user',
+            type: 'object',
+            description: 'User object',
+            itemsOrProperties: $nestedProperties,
+            required: ['id', 'name'],
+        );
+
+        $tool = new ToolInfo(
+            type: ToolTypeEnum::FUNCTION,
+            name: 'create_user',
+            description: 'Create a user',
+            parameters: [$objectParam],
+            requiredParameters: [$objectParam],
+        );
+
+        $formatted = ToolFormatter::formatTool($tool);
+
+        $this->assertSame([
+            'name' => 'create_user',
+            'description' => 'Create a user',
+            'parameters' => [
+                'type' => 'object',
+                'properties' => [
+                    'user' => [
+                        'type' => 'object',
+                        'description' => 'User object',
+                        'properties' => [
+                            'id' => [
+                                'type' => 'integer',
+                                'description' => 'The ID',
+                            ],
+                            'name' => [
+                                'type' => 'string',
+                                'description' => 'The name',
+                            ],
+                            'optional' => [
+                                'type' => 'string',
+                                'description' => 'Optional field',
+                            ],
+                        ],
+                        'required' => ['id', 'name'],
+                    ],
+                ],
+                'required' => ['user'],
+            ],
+        ], $formatted);
+    }
+
+    public function testFormatToolWithArrayOfObjectsRequired(): void
+    {
+        $nestedProperties = [
+            new Parameter('id', 'integer', 'Item ID'),
+            new Parameter('name', 'string', 'Item name'),
+        ];
+
+        $arrayParam = new Parameter(
+            name: 'items',
+            type: 'array',
+            description: 'List of items',
+            itemsOrProperties: $nestedProperties,
+            required: ['id'],
+        );
+
+        $tool = new ToolInfo(
+            type: ToolTypeEnum::FUNCTION,
+            name: 'process_items',
+            description: 'Process items',
+            parameters: [$arrayParam],
+            requiredParameters: [$arrayParam],
+        );
+
+        $formatted = ToolFormatter::formatTool($tool);
+
+        $this->assertSame([
+            'name' => 'process_items',
+            'description' => 'Process items',
+            'parameters' => [
+                'type' => 'object',
+                'properties' => [
+                    'items' => [
+                        'type' => 'array',
+                        'description' => 'List of items',
+                        'items' => [
+                            'type' => 'object',
+                            'properties' => [
+                                'id' => [
+                                    'type' => 'integer',
+                                    'description' => 'Item ID',
+                                ],
+                                'name' => [
+                                    'type' => 'string',
+                                    'description' => 'Item name',
+                                ],
+                            ],
+                            'required' => ['id'],
+                        ],
+                    ],
+                ],
+                'required' => ['items'],
+            ],
+        ], $formatted);
+    }
+
+    public function testFormatToolWithEmptyNestedRequired(): void
+    {
+        $nestedProperties = [
+            new Parameter('id', 'integer', 'The ID'),
+        ];
+
+        $objectParam = new Parameter(
+            name: 'data',
+            type: 'object',
+            description: 'Data object',
+            itemsOrProperties: $nestedProperties,
+            required: [],
+        );
+
+        $tool = new ToolInfo(
+            type: ToolTypeEnum::FUNCTION,
+            name: 'test',
+            description: 'Test',
+            parameters: [$objectParam],
+            requiredParameters: [],
+        );
+
+        $formatted = ToolFormatter::formatTool($tool);
+
+        $this->assertArrayNotHasKey('required', $formatted['parameters']['properties']['data']);
     }
 }


### PR DESCRIPTION
- Add fromJsonSchema() static methods to Parameter and ToolInfo classes
- Support nested object types with recursive property parsing
- Handle nullable types from array notation like ["string", "null"]
- Add nullable property to Parameter class for proper type preservation
- Support enum values and format specifications in parameters
- Update all ToolFormatters (OpenAI, Mistral, FireworksAI) to handle nullable
- Add comprehensive tests for all new functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * JSON Schema import for defining tools (supports OpenAI-style shapes), with automatic parameter generation, nested objects, arrays, and propagated required flags; nullable exposed on parameters.
* **Examples**
  * Example tool method now accepts an optional unit parameter and returns unit-aware output.
* **Tests**
  * Expanded coverage for schema deserialization, nullable handling, enums, formats, nested structures, required propagation, and formatter output; test baselines updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->