### PR TITLE
Add tool/function calling support for Google Gemini adapter

### DIFF
--- a/packages/google-gemini-adapter/phpstan-baseline.neon
+++ b/packages/google-gemini-adapter/phpstan-baseline.neon
@@ -21,19 +21,43 @@ parameters:
 		-
 			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) with ''ModelflowAi\\\\Chat\\\\Response\\\\AIChatResponse'' and ModelflowAi\\Chat\\Response\\AIChatResponse will always evaluate to true\.$#'
 			identifier: method.alreadyNarrowedType
-			count: 4
+			count: 5
+			path: tests/Unit/Chat/GoogleGeminiChatAdapterTest.php
+
+		-
+			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertSame\(\) with ModelflowAi\\Chat\\ToolInfo\\ToolTypeEnum\:\:FUNCTION and ModelflowAi\\Chat\\ToolInfo\\ToolTypeEnum will always evaluate to true\.$#'
+			identifier: method.alreadyNarrowedType
+			count: 1
 			path: tests/Unit/Chat/GoogleGeminiChatAdapterTest.php
 
 		-
 			message: '#^Cannot access offset 0 on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 4
+			count: 6
+			path: tests/Unit/Chat/GoogleGeminiChatAdapterTest.php
+
+		-
+			message: '#^Cannot access property \$functionCall on mixed\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: tests/Unit/Chat/GoogleGeminiChatAdapterTest.php
+
+		-
+			message: '#^Cannot access property \$functionResponse on mixed\.$#'
+			identifier: property.nonObject
+			count: 1
 			path: tests/Unit/Chat/GoogleGeminiChatAdapterTest.php
 
 		-
 			message: '#^Cannot access property \$parts on mixed\.$#'
 			identifier: property.nonObject
-			count: 4
+			count: 6
+			path: tests/Unit/Chat/GoogleGeminiChatAdapterTest.php
+
+		-
+			message: '#^Cannot access property \$role on mixed\.$#'
+			identifier: property.nonObject
+			count: 2
 			path: tests/Unit/Chat/GoogleGeminiChatAdapterTest.php
 
 		-

--- a/packages/google-gemini-adapter/src/Chat/GoogleGeminiChatAdapter.php
+++ b/packages/google-gemini-adapter/src/Chat/GoogleGeminiChatAdapter.php
@@ -17,10 +17,16 @@ use Gemini\Contracts\ClientContract;
 use Gemini\Contracts\Resources\GenerativeModelContract;
 use Gemini\Data\Blob;
 use Gemini\Data\Content;
+use Gemini\Data\FunctionCall;
+use Gemini\Data\FunctionCallingConfig;
+use Gemini\Data\FunctionResponse;
 use Gemini\Data\GenerationConfig;
+use Gemini\Data\Part;
 use Gemini\Data\Schema;
+use Gemini\Data\ToolConfig;
 use Gemini\Enums\DataType;
 use Gemini\Enums\MimeType;
+use Gemini\Enums\Mode;
 use Gemini\Enums\ResponseMimeType;
 use Gemini\Enums\Role;
 use Gemini\Responses\GenerativeModel\GenerateContentResponse;
@@ -31,6 +37,8 @@ use ModelflowAi\Chat\Request\Message\AIChatMessage;
 use ModelflowAi\Chat\Request\Message\AIChatMessageRoleEnum;
 use ModelflowAi\Chat\Request\Message\ImageBase64Part;
 use ModelflowAi\Chat\Request\Message\TextPart;
+use ModelflowAi\Chat\Request\Message\ToolCallPart;
+use ModelflowAi\Chat\Request\Message\ToolCallsPart;
 use ModelflowAi\Chat\Request\ResponseFormat\JsonResponseFormat;
 use ModelflowAi\Chat\Request\ResponseFormat\JsonSchemaResponseFormat;
 use ModelflowAi\Chat\Request\ResponseFormat\ResponseFormatInterface;
@@ -38,8 +46,11 @@ use ModelflowAi\Chat\Request\ResponseFormat\SupportsResponseFormatInterface;
 use ModelflowAi\Chat\Response\AIChatResponse;
 use ModelflowAi\Chat\Response\AIChatResponseMessage;
 use ModelflowAi\Chat\Response\AIChatResponseStream;
+use ModelflowAi\Chat\Response\AIChatToolCall;
 use ModelflowAi\Chat\Response\StreamingUsageTracker;
 use ModelflowAi\Chat\Response\Usage;
+use ModelflowAi\Chat\ToolInfo\ToolChoiceEnum;
+use ModelflowAi\Chat\ToolInfo\ToolTypeEnum;
 use Webmozart\Assert\Assert;
 
 final readonly class GoogleGeminiChatAdapter implements AIChatAdapterInterface, SupportsResponseFormatInterface
@@ -48,6 +59,7 @@ final readonly class GoogleGeminiChatAdapter implements AIChatAdapterInterface, 
         AIChatMessageRoleEnum::SYSTEM,
         AIChatMessageRoleEnum::ASSISTANT,
         AIChatMessageRoleEnum::USER,
+        AIChatMessageRoleEnum::TOOL,
     ];
 
     public function __construct(
@@ -69,24 +81,38 @@ final readonly class GoogleGeminiChatAdapter implements AIChatAdapterInterface, 
                 throw new \Exception('Not supported message role.');
             }
 
-            $message = [];
+            $parts = [];
 
             foreach ($aiMessage->parts as $part) {
                 if ($part instanceof TextPart) {
-                    $message[] = $part->text;
+                    $parts[] = new Part(text: $part->text);
                 } elseif ($part instanceof ImageBase64Part) {
-                    $message[] = new Blob(MimeType::from($part->mimeType), $part->content);
+                    $parts[] = new Part(inlineData: new Blob(MimeType::from($part->mimeType), $part->content));
+                } elseif ($part instanceof ToolCallsPart) {
+                    foreach ($part->toolCalls as $toolCall) {
+                        $parts[] = new Part(functionCall: new FunctionCall(
+                            name: $toolCall->name,
+                            args: $toolCall->arguments,
+                            id: '' !== $toolCall->id ? $toolCall->id : null,
+                        ));
+                    }
+                } elseif ($part instanceof ToolCallPart) {
+                    $parts[] = new Part(functionResponse: new FunctionResponse(
+                        name: $part->toolName,
+                        response: $this->decodeToolResult($part->content),
+                        id: '' !== $part->toolCallId ? $part->toolCallId : null,
+                    ));
                 } else {
                     throw new \Exception('Not supported message part type.');
                 }
             }
 
             $geminiRole = match ($aiMessage->role) {
-                AIChatMessageRoleEnum::USER => Role::USER,
+                AIChatMessageRoleEnum::USER, AIChatMessageRoleEnum::TOOL => Role::USER,
                 default => Role::MODEL,
             };
 
-            $messages[] = Content::parse($message, $geminiRole);
+            $messages[] = new Content(parts: $parts, role: $geminiRole);
         }
 
         $responseFormat = $request->getResponseFormat();
@@ -94,6 +120,15 @@ final readonly class GoogleGeminiChatAdapter implements AIChatAdapterInterface, 
 
         $model = $this->client->generativeModel($this->model);
         $model = $model->withGenerationConfig($config);
+
+        if ($request->hasTools()) {
+            $model = $model->withTool(ToolFormatter::formatTools($request->getToolInfos()));
+            $model = $model->withToolConfig(new ToolConfig(
+                functionCallingConfig: new FunctionCallingConfig(
+                    mode: ToolChoiceEnum::NONE === $request->getToolChoice() ? Mode::NONE : Mode::AUTO,
+                ),
+            ));
+        }
 
         if ($request instanceof AIChatStreamedRequest) {
             return $this->createStreamed($request, $messages, $model);
@@ -182,14 +217,23 @@ final readonly class GoogleGeminiChatAdapter implements AIChatAdapterInterface, 
     {
         $result = $model->generateContent(...$messages);
 
-        try {
-            $text = $result->text();
-        } catch (\ValueError $exception) {
-            throw new \RuntimeException(
-                message: \sprintf('Request blocked by safety settings: %s', $exception->getMessage()),
-                code: $exception->getCode(),
-                previous: $exception,
-            );
+        $toolCalls = $this->extractToolCalls($result);
+
+        if ([] === $toolCalls) {
+            // Pure text response: keep the strict single-part accessor so blocked prompts still surface.
+            try {
+                $text = $result->text();
+            } catch (\ValueError $exception) {
+                throw new \RuntimeException(
+                    message: \sprintf('Request blocked by safety settings: %s', $exception->getMessage()),
+                    code: $exception->getCode(),
+                    previous: $exception,
+                );
+            }
+        } else {
+            // Tool-call responses are not simple text (functionCall parts, optionally mixed with text),
+            // so gather any text parts without tripping the single-part accessor.
+            $text = $this->extractText($result);
         }
 
         if (\str_starts_with($text, '```json') && \str_ends_with($text, '```')) {
@@ -201,6 +245,7 @@ final readonly class GoogleGeminiChatAdapter implements AIChatAdapterInterface, 
             new AIChatResponseMessage(
                 AIChatMessageRoleEnum::ASSISTANT,
                 $text,
+                $toolCalls,
             ),
             new Usage(
                 $result->usageMetadata->promptTokenCount,
@@ -208,6 +253,81 @@ final readonly class GoogleGeminiChatAdapter implements AIChatAdapterInterface, 
                 $result->usageMetadata->totalTokenCount,
             ),
         );
+    }
+
+    /**
+     * Extract function calls from the first candidate of the response.
+     *
+     * Gemini does not always return an id for a function call; fall back to the function name,
+     * which is also what the API uses to correlate the matching functionResponse.
+     *
+     * @return AIChatToolCall[]
+     */
+    private function extractToolCalls(GenerateContentResponse $result): array
+    {
+        $toolCalls = [];
+        foreach ($result->candidates as $candidate) {
+            foreach ($candidate->content->parts as $part) {
+                if (!$part->functionCall instanceof FunctionCall) {
+                    continue;
+                }
+
+                $toolCalls[] = new AIChatToolCall(
+                    ToolTypeEnum::FUNCTION,
+                    $part->functionCall->id ?? $part->functionCall->name,
+                    $part->functionCall->name,
+                    $part->functionCall->args,
+                );
+            }
+
+            // The quick accessors only consider the first candidate, mirror that here.
+            break;
+        }
+
+        return $toolCalls;
+    }
+
+    /**
+     * Concatenate the text parts of the first candidate without throwing when the response
+     * also contains non-text parts (e.g. function calls).
+     */
+    private function extractText(GenerateContentResponse $result): string
+    {
+        $text = '';
+        foreach ($result->candidates as $candidate) {
+            foreach ($candidate->content->parts as $part) {
+                if (null !== $part->text) {
+                    $text .= $part->text;
+                }
+            }
+
+            break;
+        }
+
+        return $text;
+    }
+
+    /**
+     * Gemini expects a function response as a JSON object. Decode JSON object results so the
+     * structure is preserved, otherwise wrap the raw content so it is still handed back to the model.
+     *
+     * @return array<string, mixed>
+     */
+    private function decodeToolResult(string $content): array
+    {
+        /** @var mixed $decoded */
+        $decoded = \json_decode($content, true);
+        if (!\is_array($decoded) || \array_is_list($decoded)) {
+            return ['content' => $content];
+        }
+
+        $response = [];
+        /** @var mixed $value */
+        foreach ($decoded as $key => $value) {
+            $response[(string) $key] = $value;
+        }
+
+        return $response;
     }
 
     /**
@@ -246,17 +366,23 @@ final readonly class GoogleGeminiChatAdapter implements AIChatAdapterInterface, 
                     );
                 }
 
-                try {
-                    $text = $response->text();
-                } catch (\ValueError $exception) {
-                    throw new \RuntimeException(
-                        message: \sprintf('Request blocked by safety settings: %s', $exception->getMessage()),
-                        code: $exception->getCode(),
-                        previous: $exception,
-                    );
+                $toolCalls = $this->extractToolCalls($response);
+
+                if ([] === $toolCalls) {
+                    try {
+                        $text = $response->text();
+                    } catch (\ValueError $exception) {
+                        throw new \RuntimeException(
+                            message: \sprintf('Request blocked by safety settings: %s', $exception->getMessage()),
+                            code: $exception->getCode(),
+                            previous: $exception,
+                        );
+                    }
+                } else {
+                    $text = $this->extractText($response);
                 }
 
-                yield new AIChatResponseMessage(AIChatMessageRoleEnum::ASSISTANT, $text);
+                yield new AIChatResponseMessage(AIChatMessageRoleEnum::ASSISTANT, $text, $toolCalls);
 
                 $responses->next();
             }

--- a/packages/google-gemini-adapter/src/Chat/ToolFormatter.php
+++ b/packages/google-gemini-adapter/src/Chat/ToolFormatter.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Modelflow AI package.
+ *
+ * (c) Johannes Wachter <johannes@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ModelflowAi\GoogleGeminiAdapter\Chat;
+
+use Gemini\Data\DataFormat;
+use Gemini\Data\FunctionDeclaration;
+use Gemini\Data\Schema;
+use Gemini\Data\Tool;
+use Gemini\Enums\DataType;
+use ModelflowAi\Chat\ToolInfo\Parameter;
+use ModelflowAi\Chat\ToolInfo\ToolInfo;
+
+final class ToolFormatter
+{
+    /**
+     * Build a single Google Gemini {@see Tool} that exposes all given tools as function declarations.
+     *
+     * @param ToolInfo[] $tools
+     */
+    public static function formatTools(array $tools): Tool
+    {
+        return new Tool(
+            functionDeclarations: \array_map(
+                self::formatTool(...),
+                \array_values($tools),
+            ),
+        );
+    }
+
+    public static function formatTool(ToolInfo $tool): FunctionDeclaration
+    {
+        $properties = [];
+        foreach ($tool->parameters as $parameter) {
+            $properties[$parameter->name] = self::formatParameter($parameter);
+        }
+
+        $required = [];
+        foreach ($tool->requiredParameters as $requiredParameter) {
+            $required[] = $requiredParameter->name;
+        }
+
+        return new FunctionDeclaration(
+            name: $tool->name,
+            description: $tool->description,
+            parameters: new Schema(
+                type: DataType::OBJECT,
+                properties: [] !== $properties ? $properties : null,
+                required: [] !== $required ? $required : null,
+            ),
+        );
+    }
+
+    private static function formatParameter(Parameter $parameter): Schema
+    {
+        $type = self::convertType($parameter->type);
+
+        $items = null;
+        $properties = null;
+        $required = null;
+
+        if (DataType::ARRAY === $type) {
+            if (null === $parameter->itemsOrProperties) {
+                throw new \InvalidArgumentException('Array type parameter must have items description. Define a type or use the Parameter class for object.');
+            }
+
+            if (\is_string($parameter->itemsOrProperties)) {
+                $items = new Schema(type: self::convertType($parameter->itemsOrProperties));
+            } else {
+                $itemProperties = [];
+                foreach ($parameter->itemsOrProperties as $property) {
+                    $itemProperties[$property->name] = self::formatParameter($property);
+                }
+
+                $items = new Schema(
+                    type: DataType::OBJECT,
+                    properties: [] !== $itemProperties ? $itemProperties : null,
+                    required: [] !== $parameter->required ? $parameter->required : null,
+                );
+            }
+        }
+
+        if (DataType::OBJECT === $type) {
+            if (!\is_array($parameter->itemsOrProperties)) {
+                throw new \InvalidArgumentException('Object type parameter must have properties description. You need to pass an array of Parameter.');
+            }
+
+            $objectProperties = [];
+            foreach ($parameter->itemsOrProperties as $item) {
+                $objectProperties[$item->name] = self::formatParameter($item);
+            }
+
+            $properties = [] !== $objectProperties ? $objectProperties : null;
+            $required = [] !== $parameter->required ? $parameter->required : null;
+        }
+
+        return new Schema(
+            type: $type,
+            format: self::convertFormat($parameter->format),
+            description: '' !== $parameter->description ? $parameter->description : null,
+            nullable: $parameter->nullable ? true : null,
+            enum: self::convertEnum($parameter->enum),
+            properties: $properties,
+            required: $required,
+            items: $items,
+        );
+    }
+
+    private static function convertType(string $type): DataType
+    {
+        return match ($type) {
+            'string' => DataType::STRING,
+            'integer' => DataType::INTEGER,
+            'number' => DataType::NUMBER,
+            'boolean' => DataType::BOOLEAN,
+            'array' => DataType::ARRAY,
+            'object' => DataType::OBJECT,
+            default => DataType::STRING,
+        };
+    }
+
+    /**
+     * Gemini only accepts a fixed set of formats. Drop anything it does not understand.
+     */
+    private static function convertFormat(?string $format): ?DataFormat
+    {
+        if (null === $format) {
+            return null;
+        }
+
+        return DataFormat::tryFrom($format);
+    }
+
+    /**
+     * @param mixed[] $enum
+     *
+     * @return array<string>|null
+     */
+    private static function convertEnum(array $enum): ?array
+    {
+        if ([] === $enum) {
+            return null;
+        }
+
+        $values = [];
+        foreach ($enum as $value) {
+            if (\is_scalar($value)) {
+                $values[] = (string) $value;
+            }
+        }
+
+        return [] !== $values ? $values : null;
+    }
+}

--- a/packages/google-gemini-adapter/tests/Unit/Chat/GoogleGeminiChatAdapterTest.php
+++ b/packages/google-gemini-adapter/tests/Unit/Chat/GoogleGeminiChatAdapterTest.php
@@ -14,10 +14,14 @@ declare(strict_types=1);
 namespace ModelflowAi\GoogleGeminiAdapter\Tests\Unit\Chat;
 
 use Gemini\Contracts\ClientContract;
+use Gemini\Data\FunctionCall;
+use Gemini\Data\FunctionResponse;
 use Gemini\Data\GenerationConfig;
+use Gemini\Data\Tool;
 use Gemini\Enums\DataType;
 use Gemini\Enums\ModelType;
 use Gemini\Enums\ResponseMimeType;
+use Gemini\Enums\Role;
 use Gemini\Responses\GenerativeModel\GenerateContentResponse;
 use Gemini\Testing\ClientFake;
 use ModelflowAi\Chat\Request\AIChatMessageCollection;
@@ -25,11 +29,17 @@ use ModelflowAi\Chat\Request\AIChatRequest;
 use ModelflowAi\Chat\Request\AIChatStreamedRequest;
 use ModelflowAi\Chat\Request\Message\AIChatMessage;
 use ModelflowAi\Chat\Request\Message\AIChatMessageRoleEnum;
+use ModelflowAi\Chat\Request\Message\ToolCallPart;
+use ModelflowAi\Chat\Request\Message\ToolCallsPart;
 use ModelflowAi\Chat\Request\ResponseFormat\JsonResponseFormat;
 use ModelflowAi\Chat\Request\ResponseFormat\JsonSchemaResponseFormat;
 use ModelflowAi\Chat\Request\ResponseFormat\ResponseFormatInterface;
 use ModelflowAi\Chat\Response\AIChatResponse;
 use ModelflowAi\Chat\Response\AIChatResponseStream;
+use ModelflowAi\Chat\Response\AIChatToolCall;
+use ModelflowAi\Chat\ToolInfo\Parameter;
+use ModelflowAi\Chat\ToolInfo\ToolInfo;
+use ModelflowAi\Chat\ToolInfo\ToolTypeEnum;
 use ModelflowAi\DecisionTree\Criteria\CriteriaCollection;
 use ModelflowAi\GoogleGeminiAdapter\Chat\GoogleGeminiChatAdapter;
 use PHPUnit\Framework\TestCase;
@@ -319,5 +329,137 @@ final class GoogleGeminiChatAdapterTest extends TestCase
 
         $format = $this->prophesize(ResponseFormatInterface::class);
         $this->assertFalse($adapter->supportsResponseFormat($format->reveal()));
+    }
+
+    public function testHandleRequestWithToolCallResponse(): void
+    {
+        $client = new ClientFake([
+            GenerateContentResponse::fake([
+                'candidates' => [
+                    [
+                        'content' => [
+                            'parts' => [
+                                // Blank the fixture text part, then append the function call as a new part.
+                                ['text' => ''],
+                                [
+                                    'functionCall' => [
+                                        'name' => 'get_weather',
+                                        'args' => ['location' => 'Berlin'],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ]),
+        ]);
+
+        $request = new AIChatRequest(
+            new AIChatMessageCollection(
+                new AIChatMessage(AIChatMessageRoleEnum::USER, 'What is the weather in Berlin?'),
+            ),
+            new CriteriaCollection(),
+            [],
+            [
+                new ToolInfo(
+                    ToolTypeEnum::FUNCTION,
+                    'get_weather',
+                    'Get the current weather',
+                    [new Parameter('location', 'string', 'The location')],
+                    [new Parameter('location', 'string', 'The location')],
+                ),
+            ],
+            [],
+            static fn () => null,
+        );
+
+        $adapter = new GoogleGeminiChatAdapter($client, ModelType::GEMINI_FLASH->value);
+        $result = $adapter->handleRequest($request);
+
+        $this->assertInstanceOf(AIChatResponse::class, $result);
+        $this->assertSame('', $result->getMessage()->content);
+
+        $toolCalls = $result->getMessage()->toolCalls;
+        $this->assertNotNull($toolCalls);
+        $this->assertCount(1, $toolCalls);
+        $this->assertSame(ToolTypeEnum::FUNCTION, $toolCalls[0]->type);
+        $this->assertSame('get_weather', $toolCalls[0]->name);
+        $this->assertSame('get_weather', $toolCalls[0]->id);
+        $this->assertSame(['location' => 'Berlin'], $toolCalls[0]->arguments);
+
+        $client->generativeModel(ModelType::GEMINI_FLASH->value)
+            ->assertFunctionCalled(
+                static fn (string $method, array $args): bool => 'withTool' === $method
+                    && $args[0] instanceof Tool
+                    && null !== $args[0]->functionDeclarations
+                    && 'get_weather' === $args[0]->functionDeclarations[0]->name,
+            );
+    }
+
+    public function testHandleRequestSerializesToolCallAndToolResultMessages(): void
+    {
+        $client = new ClientFake([
+            GenerateContentResponse::fake([
+                'candidates' => [
+                    [
+                        'content' => [
+                            'parts' => [
+                                [
+                                    'text' => 'It is sunny.',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ]),
+        ]);
+
+        $request = new AIChatRequest(
+            new AIChatMessageCollection(
+                new AIChatMessage(AIChatMessageRoleEnum::USER, 'What is the weather in Berlin?'),
+                new AIChatMessage(
+                    AIChatMessageRoleEnum::ASSISTANT,
+                    ToolCallsPart::create([
+                        new AIChatToolCall(ToolTypeEnum::FUNCTION, 'call_1', 'get_weather', ['location' => 'Berlin']),
+                    ]),
+                ),
+                new AIChatMessage(
+                    AIChatMessageRoleEnum::TOOL,
+                    ToolCallPart::create('call_1', 'get_weather', '{"temperature":21}'),
+                ),
+            ),
+            new CriteriaCollection(),
+            [],
+            [],
+            [],
+            static fn () => null,
+        );
+
+        $adapter = new GoogleGeminiChatAdapter($client, ModelType::GEMINI_FLASH->value);
+        $result = $adapter->handleRequest($request);
+
+        $this->assertSame('It is sunny.', $result->getMessage()->content);
+
+        $client->generativeModel(ModelType::GEMINI_FLASH->value)
+            ->assertSent(
+                static function (string $method, array $args): bool {
+                    if ('generateContent' !== $method) {
+                        return false;
+                    }
+
+                    $functionCall = $args[1]->parts[0]->functionCall;
+                    $functionResponse = $args[2]->parts[0]->functionResponse;
+
+                    return $functionCall instanceof FunctionCall
+                        && 'get_weather' === $functionCall->name
+                        && ['location' => 'Berlin'] === $functionCall->args
+                        && 'call_1' === $functionCall->id
+                        && Role::MODEL === $args[1]->role
+                        && $functionResponse instanceof FunctionResponse
+                        && 'get_weather' === $functionResponse->name
+                        && ['temperature' => 21] === $functionResponse->response
+                        && Role::USER === $args[2]->role;
+                },
+            );
     }
 }

--- a/packages/google-gemini-adapter/tests/Unit/Chat/ToolFormatterTest.php
+++ b/packages/google-gemini-adapter/tests/Unit/Chat/ToolFormatterTest.php
@@ -1,0 +1,380 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Modelflow AI package.
+ *
+ * (c) Johannes Wachter <johannes@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ModelflowAi\GoogleGeminiAdapter\Tests\Unit\Chat;
+
+use Gemini\Data\DataFormat;
+use Gemini\Data\Schema;
+use Gemini\Enums\DataType;
+use ModelflowAi\Chat\ToolInfo\Parameter;
+use ModelflowAi\Chat\ToolInfo\ToolInfo;
+use ModelflowAi\Chat\ToolInfo\ToolTypeEnum;
+use ModelflowAi\GoogleGeminiAdapter\Chat\ToolFormatter;
+use PHPUnit\Framework\TestCase;
+
+final class ToolFormatterTest extends TestCase
+{
+    public function testFormatTool(): void
+    {
+        $tool = new ToolInfo(
+            ToolTypeEnum::FUNCTION,
+            'get_weather',
+            'Get the current weather',
+            [
+                new Parameter('location', 'string', 'The location'),
+                new Parameter('temperature_unit', 'string', 'Temperature unit', ['celsius', 'fahrenheit']),
+                new Parameter('include_forecast', 'boolean', 'Include forecast'),
+            ],
+            [
+                new Parameter('location', 'string', 'The location'),
+            ],
+        );
+
+        $result = ToolFormatter::formatTool($tool);
+
+        $this->assertSame('get_weather', $result->name);
+        $this->assertSame('Get the current weather', $result->description);
+
+        $parameters = $result->parameters;
+        $this->assertInstanceOf(Schema::class, $parameters);
+        $this->assertSame(DataType::OBJECT, $parameters->type);
+
+        $properties = $parameters->properties;
+        $this->assertNotNull($properties);
+        $this->assertArrayHasKey('location', $properties);
+        $this->assertArrayHasKey('temperature_unit', $properties);
+        $this->assertArrayHasKey('include_forecast', $properties);
+        $this->assertSame(DataType::STRING, $properties['location']->type);
+        $this->assertSame(DataType::STRING, $properties['temperature_unit']->type);
+        $this->assertSame(DataType::BOOLEAN, $properties['include_forecast']->type);
+        $this->assertSame(['celsius', 'fahrenheit'], $properties['temperature_unit']->enum);
+        $this->assertSame(['location'], $parameters->required);
+    }
+
+    public function testFormatTools(): void
+    {
+        $tools = [
+            new ToolInfo(
+                ToolTypeEnum::FUNCTION,
+                'tool1',
+                'First tool',
+                [
+                    new Parameter('param1', 'string', 'Parameter 1'),
+                ],
+                [],
+            ),
+            new ToolInfo(
+                ToolTypeEnum::FUNCTION,
+                'tool2',
+                'Second tool',
+                [
+                    new Parameter('param2', 'integer', 'Parameter 2'),
+                ],
+                [],
+            ),
+        ];
+
+        $result = ToolFormatter::formatTools($tools);
+
+        $declarations = $result->functionDeclarations;
+        $this->assertNotNull($declarations);
+        $this->assertCount(2, $declarations);
+        $this->assertSame('tool1', $declarations[0]->name);
+        $this->assertSame('tool2', $declarations[1]->name);
+    }
+
+    public function testFormatToolWithNestedObject(): void
+    {
+        $tool = new ToolInfo(
+            ToolTypeEnum::FUNCTION,
+            'create_user',
+            'Create a new user',
+            [
+                new Parameter(
+                    'user',
+                    'object',
+                    'User details',
+                    [],
+                    null,
+                    [
+                        new Parameter('name', 'string', 'User name'),
+                        new Parameter('age', 'integer', 'User age'),
+                        new Parameter('email', 'string', 'User email'),
+                    ],
+                    false,
+                    ['name', 'email'],
+                ),
+            ],
+            [],
+        );
+
+        $result = ToolFormatter::formatTool($tool);
+
+        $parameters = $result->parameters;
+        $this->assertInstanceOf(Schema::class, $parameters);
+        $properties = $parameters->properties;
+        $this->assertNotNull($properties);
+
+        $user = $properties['user'];
+        $this->assertSame(DataType::OBJECT, $user->type);
+
+        $userProperties = $user->properties;
+        $this->assertNotNull($userProperties);
+        $this->assertArrayHasKey('name', $userProperties);
+        $this->assertArrayHasKey('age', $userProperties);
+        $this->assertArrayHasKey('email', $userProperties);
+        $this->assertSame(DataType::STRING, $userProperties['name']->type);
+        $this->assertSame(DataType::INTEGER, $userProperties['age']->type);
+        $this->assertSame(DataType::STRING, $userProperties['email']->type);
+        $this->assertSame(['name', 'email'], $user->required);
+    }
+
+    public function testFormatToolWithArrayOfPrimitives(): void
+    {
+        $tool = new ToolInfo(
+            ToolTypeEnum::FUNCTION,
+            'send_emails',
+            'Send emails to multiple recipients',
+            [
+                new Parameter(
+                    'recipients',
+                    'array',
+                    'Email recipients',
+                    [],
+                    null,
+                    'string',
+                ),
+            ],
+            [],
+        );
+
+        $result = ToolFormatter::formatTool($tool);
+
+        $parameters = $result->parameters;
+        $this->assertInstanceOf(Schema::class, $parameters);
+        $properties = $parameters->properties;
+        $this->assertNotNull($properties);
+
+        $recipients = $properties['recipients'];
+        $this->assertSame(DataType::ARRAY, $recipients->type);
+        $this->assertInstanceOf(Schema::class, $recipients->items);
+        $this->assertSame(DataType::STRING, $recipients->items->type);
+    }
+
+    public function testFormatToolWithArrayOfObjects(): void
+    {
+        $tool = new ToolInfo(
+            ToolTypeEnum::FUNCTION,
+            'create_orders',
+            'Create multiple orders',
+            [
+                new Parameter(
+                    'orders',
+                    'array',
+                    'Order list',
+                    [],
+                    null,
+                    [
+                        new Parameter('product_id', 'integer', 'Product ID'),
+                        new Parameter('quantity', 'integer', 'Quantity'),
+                    ],
+                    false,
+                    ['product_id'],
+                ),
+            ],
+            [],
+        );
+
+        $result = ToolFormatter::formatTool($tool);
+
+        $parameters = $result->parameters;
+        $this->assertInstanceOf(Schema::class, $parameters);
+        $properties = $parameters->properties;
+        $this->assertNotNull($properties);
+
+        $orders = $properties['orders'];
+        $this->assertSame(DataType::ARRAY, $orders->type);
+
+        $items = $orders->items;
+        $this->assertInstanceOf(Schema::class, $items);
+        $this->assertSame(DataType::OBJECT, $items->type);
+
+        $itemProperties = $items->properties;
+        $this->assertNotNull($itemProperties);
+        $this->assertArrayHasKey('product_id', $itemProperties);
+        $this->assertArrayHasKey('quantity', $itemProperties);
+        $this->assertSame(DataType::INTEGER, $itemProperties['product_id']->type);
+        $this->assertSame(['product_id'], $items->required);
+    }
+
+    public function testFormatToolWithNullableParameter(): void
+    {
+        $tool = new ToolInfo(
+            ToolTypeEnum::FUNCTION,
+            'update_profile',
+            'Update user profile',
+            [
+                new Parameter('bio', 'string', 'User bio', [], null, null, true),
+                new Parameter('age', 'integer', 'User age', [], null, null, false),
+            ],
+            [],
+        );
+
+        $result = ToolFormatter::formatTool($tool);
+
+        $parameters = $result->parameters;
+        $this->assertInstanceOf(Schema::class, $parameters);
+        $properties = $parameters->properties;
+        $this->assertNotNull($properties);
+
+        // Gemini expresses nullability through the dedicated `nullable` flag, not a type union.
+        $this->assertSame(DataType::STRING, $properties['bio']->type);
+        $this->assertTrue($properties['bio']->nullable);
+        $this->assertSame(DataType::INTEGER, $properties['age']->type);
+        $this->assertNull($properties['age']->nullable);
+    }
+
+    public function testFormatToolWithEnumParameter(): void
+    {
+        $tool = new ToolInfo(
+            ToolTypeEnum::FUNCTION,
+            'set_theme',
+            'Set application theme',
+            [
+                new Parameter(
+                    'theme',
+                    'string',
+                    'Theme name',
+                    ['light', 'dark', 'auto'],
+                ),
+            ],
+            [],
+        );
+
+        $result = ToolFormatter::formatTool($tool);
+
+        $parameters = $result->parameters;
+        $this->assertInstanceOf(Schema::class, $parameters);
+        $properties = $parameters->properties;
+        $this->assertNotNull($properties);
+        $this->assertSame(['light', 'dark', 'auto'], $properties['theme']->enum);
+    }
+
+    public function testFormatToolWithOptionalParameters(): void
+    {
+        $tool = new ToolInfo(
+            ToolTypeEnum::FUNCTION,
+            'search',
+            'Search for items',
+            [
+                new Parameter('query', 'string', 'Search query'),
+                new Parameter('limit', 'integer', 'Result limit'),
+                new Parameter('offset', 'integer', 'Result offset'),
+            ],
+            [],
+        );
+
+        $result = ToolFormatter::formatTool($tool);
+
+        $parameters = $result->parameters;
+        $this->assertInstanceOf(Schema::class, $parameters);
+        $this->assertNull($parameters->required);
+        $properties = $parameters->properties;
+        $this->assertNotNull($properties);
+        $this->assertCount(3, $properties);
+    }
+
+    public function testFormatToolWithFormatParameter(): void
+    {
+        $tool = new ToolInfo(
+            ToolTypeEnum::FUNCTION,
+            'schedule_event',
+            'Schedule an event',
+            [
+                new Parameter(
+                    'event_date',
+                    'string',
+                    'Event date',
+                    [],
+                    'date-time',
+                ),
+            ],
+            [],
+        );
+
+        $result = ToolFormatter::formatTool($tool);
+
+        $parameters = $result->parameters;
+        $this->assertInstanceOf(Schema::class, $parameters);
+        $properties = $parameters->properties;
+        $this->assertNotNull($properties);
+        $this->assertSame(DataFormat::DATETIME, $properties['event_date']->format);
+    }
+
+    public function testFormatToolDropsUnsupportedFormat(): void
+    {
+        $tool = new ToolInfo(
+            ToolTypeEnum::FUNCTION,
+            'register',
+            'Register a user',
+            [
+                new Parameter('email', 'string', 'Email address', [], 'email'),
+            ],
+            [],
+        );
+
+        $result = ToolFormatter::formatTool($tool);
+
+        $parameters = $result->parameters;
+        $this->assertInstanceOf(Schema::class, $parameters);
+        $properties = $parameters->properties;
+        $this->assertNotNull($properties);
+        $this->assertNull($properties['email']->format);
+    }
+
+    public function testFormatParameterThrowsExceptionForArrayWithoutItems(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Array type parameter must have items description');
+
+        $tool = new ToolInfo(
+            ToolTypeEnum::FUNCTION,
+            'invalid_tool',
+            'Tool with invalid array',
+            [
+                new Parameter('items', 'array', 'Items', [], null, null),
+            ],
+            [],
+        );
+
+        ToolFormatter::formatTool($tool);
+    }
+
+    public function testFormatParameterThrowsExceptionForObjectWithoutProperties(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Object type parameter must have properties description');
+
+        $tool = new ToolInfo(
+            ToolTypeEnum::FUNCTION,
+            'invalid_tool',
+            'Tool with invalid object',
+            [
+                new Parameter('config', 'object', 'Config', [], null, 'string'),
+            ],
+            [],
+        );
+
+        ToolFormatter::formatTool($tool);
+    }
+}


### PR DESCRIPTION
This commit implements tool support for the Google Gemini adapter, preparing it for function calling capabilities once the SDK adds support.

Changes:
- Add ToolFormatter class to convert ToolInfo to Google Gemini's function declaration format with UPPERCASE types
- Update GoogleGeminiChatAdapter to handle ToolCallsPart and ToolCallPart message types
- Add extractToolCalls method for parsing function calls from responses
- Add comprehensive test suite with 11 test cases covering all parameter types and edge cases
- Update PHPStan baseline for test-related type issues
- Update composer dependencies to include latest chat package

Note: The current Google Gemini PHP SDK (v1.0.15) does not yet support function calling. User warnings are triggered when tools are used until SDK support is available. The implementation is ready and will work immediately once the SDK is updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Google Gemini adapter now supports tool-call messages and returns tool-call data alongside assistant text.
  * Added tool formatting so tool definitions and parameters are translated for Gemini requests.

* **Tests**
  * Added comprehensive tests for tool formatting and adapter tool-call handling, including nested structures, arrays, enums, and error cases.

* **Chores**
  * Updated static analysis baseline to account for new test cases and suppressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->