### PR TITLE
[codex] Add Mistral OCR client resource

### DIFF
--- a/packages/google-gemini-adapter/src/Chat/GoogleGeminiChatAdapter.php
+++ b/packages/google-gemini-adapter/src/Chat/GoogleGeminiChatAdapter.php
@@ -160,7 +160,7 @@ final readonly class GoogleGeminiChatAdapter implements AIChatAdapterInterface, 
             );
         }
 
-        if ($responseMimeType instanceof ResponseMimeType || $responseSchema instanceof Schema) {
+        if ($responseMimeType instanceof ResponseMimeType) {
             return new GenerationConfig(
                 responseMimeType: $responseMimeType,
                 responseSchema: $responseSchema,

--- a/packages/mistral/examples/ocr-blocks.php
+++ b/packages/mistral/examples/ocr-blocks.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Modelflow AI package.
+ *
+ * (c) Johannes Wachter <johannes@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use ModelflowAi\Mistral\Mistral;
+use ModelflowAi\Mistral\Model;
+use Symfony\Component\Dotenv\Dotenv;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+(new Dotenv())->bootEnv(__DIR__ . '/.env');
+
+$apiKey = $_ENV['MISTRAL_API_KEY'] ?? null;
+if (!\is_string($apiKey)) {
+    throw new RuntimeException('The MISTRAL_API_KEY environment variable is required.');
+}
+
+$client = Mistral::client($apiKey);
+$documentUrl = $argv[1] ?? 'https://arxiv.org/pdf/2201.04234';
+
+$response = $client->ocr()->process([
+    'model' => Model::OCR_4->value,
+    'document' => [
+        'type' => 'document_url',
+        'document_url' => $documentUrl,
+    ],
+    'pages' => '0',
+    'include_blocks' => true,
+]);
+
+foreach ($response->pages[0]->blocks as $block) {
+    echo \sprintf(
+        "[%s] %s\n",
+        $block->type,
+        \str_replace("\n", ' ', $block->content),
+    );
+}

--- a/packages/mistral/examples/ocr-blocks.php
+++ b/packages/mistral/examples/ocr-blocks.php
@@ -25,7 +25,24 @@ if (!\is_string($apiKey)) {
 }
 
 $client = Mistral::client($apiKey);
-$documentUrl = $argv[1] ?? 'https://arxiv.org/pdf/2201.04234';
+$document = $argv[1] ?? 'https://arxiv.org/pdf/2201.04234';
+
+// The Mistral OCR API requires the document to be an https URL or a base64
+// data URI. A local file path must be read and encoded before sending.
+if (\is_file($document)) {
+    $contents = \file_get_contents($document);
+    if (false === $contents) {
+        throw new RuntimeException(\sprintf('Unable to read file "%s".', $document));
+    }
+
+    $mimeType = \mime_content_type($document) ?: 'application/pdf';
+    $documentUrl = \sprintf('data:%s;base64,%s', $mimeType, \base64_encode($contents));
+} else {
+    $documentUrl = $document;
+}
+
+// Comma-separated, zero-based page indexes (e.g. "0,1,2"). Defaults to the first page.
+$pages = $argv[2] ?? '0';
 
 $response = $client->ocr()->process([
     'model' => Model::OCR_4->value,
@@ -33,14 +50,18 @@ $response = $client->ocr()->process([
         'type' => 'document_url',
         'document_url' => $documentUrl,
     ],
-    'pages' => '0',
+    'pages' => $pages,
     'include_blocks' => true,
 ]);
 
-foreach ($response->pages[0]->blocks as $block) {
-    echo \sprintf(
-        "[%s] %s\n",
-        $block->type,
-        \str_replace("\n", ' ', $block->content),
-    );
+foreach ($response->pages as $page) {
+    echo \sprintf("=== Page %d ===\n", $page->index);
+
+    foreach ($page->blocks as $block) {
+        echo \sprintf(
+            "[%s] %s\n",
+            $block->type,
+            \str_replace("\n", ' ', $block->content),
+        );
+    }
 }

--- a/packages/mistral/examples/ocr.php
+++ b/packages/mistral/examples/ocr.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Modelflow AI package.
+ *
+ * (c) Johannes Wachter <johannes@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use ModelflowAi\Mistral\Mistral;
+use ModelflowAi\Mistral\Model;
+use Symfony\Component\Dotenv\Dotenv;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+(new Dotenv())->bootEnv(__DIR__ . '/.env');
+
+$apiKey = $_ENV['MISTRAL_API_KEY'] ?? null;
+if (!\is_string($apiKey)) {
+    throw new RuntimeException('The MISTRAL_API_KEY environment variable is required.');
+}
+
+$client = Mistral::client($apiKey);
+$documentUrl = $argv[1] ?? 'https://arxiv.org/pdf/2201.04234';
+
+$response = $client->ocr()->process([
+    'model' => Model::OCR->value,
+    'document' => [
+        'type' => 'document_url',
+        'document_url' => $documentUrl,
+    ],
+    'pages' => '0',
+]);
+
+echo $response->pages[0]->markdown . \PHP_EOL;

--- a/packages/mistral/examples/ocr.php
+++ b/packages/mistral/examples/ocr.php
@@ -25,7 +25,24 @@ if (!\is_string($apiKey)) {
 }
 
 $client = Mistral::client($apiKey);
-$documentUrl = $argv[1] ?? 'https://arxiv.org/pdf/2201.04234';
+$document = $argv[1] ?? 'https://arxiv.org/pdf/2201.04234';
+
+// The Mistral OCR API requires the document to be an https URL or a base64
+// data URI. A local file path must be read and encoded before sending.
+if (\is_file($document)) {
+    $contents = \file_get_contents($document);
+    if (false === $contents) {
+        throw new RuntimeException(\sprintf('Unable to read file "%s".', $document));
+    }
+
+    $mimeType = \mime_content_type($document) ?: 'application/pdf';
+    $documentUrl = \sprintf('data:%s;base64,%s', $mimeType, \base64_encode($contents));
+} else {
+    $documentUrl = $document;
+}
+
+// Comma-separated, zero-based page indexes (e.g. "0,1,2"). Defaults to the first page.
+$pages = $argv[2] ?? '0';
 
 $response = $client->ocr()->process([
     'model' => Model::OCR->value,
@@ -33,7 +50,25 @@ $response = $client->ocr()->process([
         'type' => 'document_url',
         'document_url' => $documentUrl,
     ],
-    'pages' => '0',
+    'pages' => $pages,
+    // Pull header/footer into separate fields so $page->markdown is the main content only.
+    'extract_header' => true,
+    'extract_footer' => true,
 ]);
 
-echo $response->pages[0]->markdown . \PHP_EOL;
+foreach ($response->pages as $page) {
+    echo \sprintf("=== Page %d ===\n", $page->index);
+
+    if (null !== $page->header) {
+        echo '--- Header ---' . \PHP_EOL;
+        echo $page->header . \PHP_EOL;
+    }
+
+    echo '--- Content ---' . \PHP_EOL;
+    echo $page->markdown . \PHP_EOL;
+
+    if (null !== $page->footer) {
+        echo '--- Footer ---' . \PHP_EOL;
+        echo $page->footer . \PHP_EOL;
+    }
+}

--- a/packages/mistral/src/Client.php
+++ b/packages/mistral/src/Client.php
@@ -18,6 +18,8 @@ use ModelflowAi\Mistral\Resources\Chat;
 use ModelflowAi\Mistral\Resources\ChatInterface;
 use ModelflowAi\Mistral\Resources\Embeddings;
 use ModelflowAi\Mistral\Resources\EmbeddingsInterface;
+use ModelflowAi\Mistral\Resources\Ocr;
+use ModelflowAi\Mistral\Resources\OcrInterface;
 
 final readonly class Client implements ClientInterface
 {
@@ -44,5 +46,15 @@ final readonly class Client implements ClientInterface
     public function embeddings(): EmbeddingsInterface
     {
         return new Embeddings($this->transport);
+    }
+
+    /**
+     * Extract text and structured content from documents and images.
+     *
+     * @see https://docs.mistral.ai/api/endpoint/ocr
+     */
+    public function ocr(): OcrInterface
+    {
+        return new Ocr($this->transport);
     }
 }

--- a/packages/mistral/src/ClientInterface.php
+++ b/packages/mistral/src/ClientInterface.php
@@ -15,6 +15,7 @@ namespace ModelflowAi\Mistral;
 
 use ModelflowAi\Mistral\Resources\ChatInterface;
 use ModelflowAi\Mistral\Resources\EmbeddingsInterface;
+use ModelflowAi\Mistral\Resources\OcrInterface;
 
 interface ClientInterface
 {
@@ -31,4 +32,11 @@ interface ClientInterface
      * @see https://docs.mistral.ai/api/#operation/createEmbedding
      */
     public function embeddings(): EmbeddingsInterface;
+
+    /**
+     * Extract text and structured content from documents and images.
+     *
+     * @see https://docs.mistral.ai/api/endpoint/ocr
+     */
+    public function ocr(): OcrInterface;
 }

--- a/packages/mistral/src/Model.php
+++ b/packages/mistral/src/Model.php
@@ -21,6 +21,8 @@ enum Model: string
     case LARGE = 'mistral-large-latest';
     case NEMO = 'open-mistral-nemo';
     case EMBED = 'mistral-embed';
+    case OCR = 'mistral-ocr-latest';
+    case OCR_4 = 'mistral-ocr-4-0';
     case PIXTRAL_LARGE = 'pixtral-large-latest';
 
     public function jsonSupported(): bool

--- a/packages/mistral/src/Resources/Ocr.php
+++ b/packages/mistral/src/Resources/Ocr.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Modelflow AI package.
+ *
+ * (c) Johannes Wachter <johannes@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ModelflowAi\Mistral\Resources;
+
+use ModelflowAi\ApiClient\Transport\Payload;
+use ModelflowAi\ApiClient\Transport\TransportInterface;
+use ModelflowAi\Mistral\Model;
+use ModelflowAi\Mistral\Responses\Ocr\ProcessResponse;
+use Webmozart\Assert\Assert;
+
+final readonly class Ocr implements OcrInterface
+{
+    public function __construct(
+        private TransportInterface $transport,
+    ) {
+    }
+
+    public function process(array $parameters): ProcessResponse
+    {
+        $this->validateParameters($parameters);
+        $parameters['model'] ??= Model::OCR->value;
+
+        $payload = Payload::create('ocr', $parameters);
+
+        $response = $this->transport->requestObject($payload);
+
+        return ProcessResponse::from($response->data, $response->meta);
+    }
+
+    /**
+     * @param array<string, mixed> $parameters
+     */
+    private function validateParameters(array $parameters): void
+    {
+        if (isset($parameters['model'])) {
+            Assert::string($parameters['model']);
+        }
+
+        Assert::keyExists($parameters, 'document');
+        Assert::isArray($parameters['document']);
+        $documentType = $parameters['document']['type'] ?? $this->detectDocumentType($parameters['document']);
+        Assert::string($documentType);
+        Assert::inArray($documentType, ['document_url', 'image_url', 'file']);
+
+        if ('document_url' === $documentType) {
+            Assert::keyExists($parameters['document'], 'document_url');
+            Assert::string($parameters['document']['document_url']);
+
+            if (isset($parameters['document']['document_name'])) {
+                Assert::string($parameters['document']['document_name']);
+            }
+        }
+
+        if ('image_url' === $documentType) {
+            Assert::keyExists($parameters['document'], 'image_url');
+            Assert::string($parameters['document']['image_url']);
+        }
+
+        if ('file' === $documentType) {
+            Assert::keyExists($parameters['document'], 'file_id');
+            Assert::string($parameters['document']['file_id']);
+        }
+
+        if (isset($parameters['pages'])) {
+            if (\is_array($parameters['pages'])) {
+                Assert::allInteger($parameters['pages']);
+            } else {
+                Assert::string($parameters['pages']);
+            }
+        }
+
+        if (isset($parameters['include_blocks'])) {
+            Assert::boolean($parameters['include_blocks']);
+        }
+        if (isset($parameters['include_image_base64'])) {
+            Assert::boolean($parameters['include_image_base64']);
+        }
+        if (isset($parameters['image_limit'])) {
+            Assert::integer($parameters['image_limit']);
+        }
+        if (isset($parameters['image_min_size'])) {
+            Assert::integer($parameters['image_min_size']);
+        }
+        if (isset($parameters['bbox_annotation_format'])) {
+            Assert::isArray($parameters['bbox_annotation_format']);
+        }
+        if (isset($parameters['document_annotation_format'])) {
+            Assert::isArray($parameters['document_annotation_format']);
+        }
+        if (isset($parameters['document_annotation_prompt'])) {
+            Assert::string($parameters['document_annotation_prompt']);
+        }
+        if (isset($parameters['table_format'])) {
+            Assert::string($parameters['table_format']);
+            Assert::inArray($parameters['table_format'], ['markdown', 'html']);
+        }
+        if (isset($parameters['extract_header'])) {
+            Assert::boolean($parameters['extract_header']);
+        }
+        if (isset($parameters['extract_footer'])) {
+            Assert::boolean($parameters['extract_footer']);
+        }
+        if (isset($parameters['confidence_scores_granularity'])) {
+            Assert::string($parameters['confidence_scores_granularity']);
+            Assert::inArray($parameters['confidence_scores_granularity'], ['word', 'page']);
+        }
+    }
+
+    /**
+     * @param array<mixed> $document
+     */
+    private function detectDocumentType(array $document): string
+    {
+        if (isset($document['document_url'])) {
+            return 'document_url';
+        }
+
+        if (isset($document['image_url'])) {
+            return 'image_url';
+        }
+
+        if (isset($document['file_id'])) {
+            return 'file';
+        }
+
+        throw new \InvalidArgumentException('The document type could not be detected.');
+    }
+}

--- a/packages/mistral/src/Resources/Ocr.php
+++ b/packages/mistral/src/Resources/Ocr.php
@@ -30,6 +30,7 @@ final readonly class Ocr implements OcrInterface
     {
         $this->validateParameters($parameters);
         $parameters['model'] ??= Model::OCR->value;
+        $parameters['document']['type'] ??= $this->detectDocumentType($parameters['document']);
 
         $payload = Payload::create('ocr', $parameters);
 

--- a/packages/mistral/src/Resources/OcrInterface.php
+++ b/packages/mistral/src/Resources/OcrInterface.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Modelflow AI package.
+ *
+ * (c) Johannes Wachter <johannes@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ModelflowAi\Mistral\Resources;
+
+use ModelflowAi\Mistral\Responses\Ocr\ProcessResponse;
+
+interface OcrInterface
+{
+    /**
+     * @param array{
+     *     model?: string|null,
+     *     document: array<string, mixed>,
+     *     pages?: string|int[]|null,
+     *     include_blocks?: bool|null,
+     *     include_image_base64?: bool|null,
+     *     image_limit?: int|null,
+     *     image_min_size?: int|null,
+     *     bbox_annotation_format?: array<string, mixed>|null,
+     *     document_annotation_format?: array<string, mixed>|null,
+     *     document_annotation_prompt?: string|null,
+     *     table_format?: 'markdown'|'html'|null,
+     *     extract_header?: bool,
+     *     extract_footer?: bool,
+     *     confidence_scores_granularity?: 'word'|'page'|null,
+     * } $parameters
+     */
+    public function process(array $parameters): ProcessResponse;
+}

--- a/packages/mistral/src/Responses/Ocr/Block.php
+++ b/packages/mistral/src/Responses/Ocr/Block.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Modelflow AI package.
+ *
+ * (c) Johannes Wachter <johannes@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ModelflowAi\Mistral\Responses\Ocr;
+
+use Webmozart\Assert\Assert;
+
+final readonly class Block
+{
+    private function __construct(
+        public string $type,
+        public ?int $topLeftX,
+        public ?int $topLeftY,
+        public ?int $bottomRightX,
+        public ?int $bottomRightY,
+        public string $content,
+        public ?string $tableId,
+        public ?string $imageId,
+    ) {
+    }
+
+    /**
+     * @param array<mixed> $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        $type = $attributes['type'];
+        $topLeftX = $attributes['top_left_x'] ?? null;
+        $topLeftY = $attributes['top_left_y'] ?? null;
+        $bottomRightX = $attributes['bottom_right_x'] ?? null;
+        $bottomRightY = $attributes['bottom_right_y'] ?? null;
+        $content = $attributes['content'] ?? '';
+        $tableId = $attributes['table_id'] ?? null;
+        $imageId = $attributes['image_id'] ?? null;
+
+        Assert::string($type);
+        Assert::nullOrInteger($topLeftX);
+        Assert::nullOrInteger($topLeftY);
+        Assert::nullOrInteger($bottomRightX);
+        Assert::nullOrInteger($bottomRightY);
+        Assert::string($content);
+        Assert::nullOrString($tableId);
+        Assert::nullOrString($imageId);
+
+        return new self(
+            $type,
+            $topLeftX,
+            $topLeftY,
+            $bottomRightX,
+            $bottomRightY,
+            $content,
+            $tableId,
+            $imageId,
+        );
+    }
+}

--- a/packages/mistral/src/Responses/Ocr/ConfidenceScore.php
+++ b/packages/mistral/src/Responses/Ocr/ConfidenceScore.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Modelflow AI package.
+ *
+ * (c) Johannes Wachter <johannes@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ModelflowAi\Mistral\Responses\Ocr;
+
+use Webmozart\Assert\Assert;
+
+final readonly class ConfidenceScore
+{
+    private function __construct(
+        public string $text,
+        public float $confidence,
+        public int $startIndex,
+    ) {
+    }
+
+    /**
+     * @param array<mixed> $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        $text = $attributes['text'];
+        $confidence = $attributes['confidence'];
+        $startIndex = $attributes['start_index'];
+
+        Assert::string($text);
+        Assert::float($confidence);
+        Assert::integer($startIndex);
+
+        return new self(
+            $text,
+            $confidence,
+            $startIndex,
+        );
+    }
+}

--- a/packages/mistral/src/Responses/Ocr/ConfidenceScore.php
+++ b/packages/mistral/src/Responses/Ocr/ConfidenceScore.php
@@ -34,12 +34,12 @@ final readonly class ConfidenceScore
         $startIndex = $attributes['start_index'];
 
         Assert::string($text);
-        Assert::float($confidence);
+        Assert::numeric($confidence);
         Assert::integer($startIndex);
 
         return new self(
             $text,
-            $confidence,
+            (float) $confidence,
             $startIndex,
         );
     }

--- a/packages/mistral/src/Responses/Ocr/ConfidenceScores.php
+++ b/packages/mistral/src/Responses/Ocr/ConfidenceScores.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Modelflow AI package.
+ *
+ * (c) Johannes Wachter <johannes@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ModelflowAi\Mistral\Responses\Ocr;
+
+use Webmozart\Assert\Assert;
+
+final readonly class ConfidenceScores
+{
+    /**
+     * @param ConfidenceScore[] $wordConfidenceScores
+     */
+    private function __construct(
+        public array $wordConfidenceScores,
+        public float $averagePageConfidenceScore,
+        public float $minimumPageConfidenceScore,
+    ) {
+    }
+
+    /**
+     * @param array<mixed> $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        $rawWordConfidenceScores = $attributes['word_confidence_scores'] ?? [];
+        $averagePageConfidenceScore = $attributes['average_page_confidence_score'];
+        $minimumPageConfidenceScore = $attributes['minimum_page_confidence_score'];
+
+        Assert::isArray($rawWordConfidenceScores);
+        Assert::float($averagePageConfidenceScore);
+        Assert::float($minimumPageConfidenceScore);
+
+        $wordConfidenceScores = \array_map(
+            static function (mixed $score): ConfidenceScore {
+                Assert::isArray($score);
+
+                return ConfidenceScore::from($score);
+            },
+            $rawWordConfidenceScores,
+        );
+
+        return new self(
+            $wordConfidenceScores,
+            $averagePageConfidenceScore,
+            $minimumPageConfidenceScore,
+        );
+    }
+}

--- a/packages/mistral/src/Responses/Ocr/ConfidenceScores.php
+++ b/packages/mistral/src/Responses/Ocr/ConfidenceScores.php
@@ -37,8 +37,10 @@ final readonly class ConfidenceScores
         $minimumPageConfidenceScore = $attributes['minimum_page_confidence_score'];
 
         Assert::isArray($rawWordConfidenceScores);
-        Assert::float($averagePageConfidenceScore);
-        Assert::float($minimumPageConfidenceScore);
+        Assert::numeric($averagePageConfidenceScore);
+        Assert::numeric($minimumPageConfidenceScore);
+        $averagePageConfidenceScore = (float) $averagePageConfidenceScore;
+        $minimumPageConfidenceScore = (float) $minimumPageConfidenceScore;
 
         $wordConfidenceScores = \array_map(
             static function (mixed $score): ConfidenceScore {

--- a/packages/mistral/src/Responses/Ocr/Dimensions.php
+++ b/packages/mistral/src/Responses/Ocr/Dimensions.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Modelflow AI package.
+ *
+ * (c) Johannes Wachter <johannes@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ModelflowAi\Mistral\Responses\Ocr;
+
+use Webmozart\Assert\Assert;
+
+final readonly class Dimensions
+{
+    private function __construct(
+        public int $dpi,
+        public int $height,
+        public int $width,
+    ) {
+    }
+
+    /**
+     * @param array<mixed> $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        $dpi = $attributes['dpi'] ?? 0;
+        $height = $attributes['height'] ?? 0;
+        $width = $attributes['width'] ?? 0;
+
+        Assert::integer($dpi);
+        Assert::integer($height);
+        Assert::integer($width);
+
+        return new self(
+            $dpi,
+            $height,
+            $width,
+        );
+    }
+}

--- a/packages/mistral/src/Responses/Ocr/Image.php
+++ b/packages/mistral/src/Responses/Ocr/Image.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Modelflow AI package.
+ *
+ * (c) Johannes Wachter <johannes@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ModelflowAi\Mistral\Responses\Ocr;
+
+use Webmozart\Assert\Assert;
+
+final readonly class Image
+{
+    private function __construct(
+        public string $id,
+        public ?int $topLeftX,
+        public ?int $topLeftY,
+        public ?int $bottomRightX,
+        public ?int $bottomRightY,
+        public ?string $imageBase64,
+        public ?string $imageAnnotation,
+    ) {
+    }
+
+    /**
+     * @param array<mixed> $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        $id = $attributes['id'];
+        $topLeftX = $attributes['top_left_x'];
+        $topLeftY = $attributes['top_left_y'];
+        $bottomRightX = $attributes['bottom_right_x'];
+        $bottomRightY = $attributes['bottom_right_y'];
+        $imageBase64 = $attributes['image_base64'] ?? null;
+        $imageAnnotation = $attributes['image_annotation'] ?? null;
+
+        Assert::string($id);
+        Assert::nullOrInteger($topLeftX);
+        Assert::nullOrInteger($topLeftY);
+        Assert::nullOrInteger($bottomRightX);
+        Assert::nullOrInteger($bottomRightY);
+        Assert::nullOrString($imageBase64);
+        Assert::nullOrString($imageAnnotation);
+
+        return new self(
+            $id,
+            $topLeftX,
+            $topLeftY,
+            $bottomRightX,
+            $bottomRightY,
+            $imageBase64,
+            $imageAnnotation,
+        );
+    }
+}

--- a/packages/mistral/src/Responses/Ocr/Image.php
+++ b/packages/mistral/src/Responses/Ocr/Image.php
@@ -34,10 +34,10 @@ final readonly class Image
     public static function from(array $attributes): self
     {
         $id = $attributes['id'];
-        $topLeftX = $attributes['top_left_x'];
-        $topLeftY = $attributes['top_left_y'];
-        $bottomRightX = $attributes['bottom_right_x'];
-        $bottomRightY = $attributes['bottom_right_y'];
+        $topLeftX = $attributes['top_left_x'] ?? null;
+        $topLeftY = $attributes['top_left_y'] ?? null;
+        $bottomRightX = $attributes['bottom_right_x'] ?? null;
+        $bottomRightY = $attributes['bottom_right_y'] ?? null;
         $imageBase64 = $attributes['image_base64'] ?? null;
         $imageAnnotation = $attributes['image_annotation'] ?? null;
 

--- a/packages/mistral/src/Responses/Ocr/Page.php
+++ b/packages/mistral/src/Responses/Ocr/Page.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Modelflow AI package.
+ *
+ * (c) Johannes Wachter <johannes@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ModelflowAi\Mistral\Responses\Ocr;
+
+use Webmozart\Assert\Assert;
+
+final readonly class Page
+{
+    /**
+     * @param Image[] $images
+     * @param Table[] $tables
+     * @param string[] $hyperlinks
+     * @param Block[] $blocks
+     */
+    private function __construct(
+        public int $index,
+        public string $markdown,
+        public array $images,
+        public ?Dimensions $dimensions,
+        public array $tables,
+        public array $hyperlinks,
+        public ?string $header,
+        public ?string $footer,
+        public ?ConfidenceScores $confidenceScores,
+        public array $blocks,
+    ) {
+    }
+
+    /**
+     * @param array<mixed> $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        $index = $attributes['index'];
+        $markdown = $attributes['markdown'];
+        $rawImages = $attributes['images'];
+        $rawDimensions = $attributes['dimensions'];
+        $rawTables = $attributes['tables'] ?? [];
+        $hyperlinks = $attributes['hyperlinks'] ?? [];
+        $header = $attributes['header'] ?? null;
+        $footer = $attributes['footer'] ?? null;
+        $rawConfidenceScores = $attributes['confidence_scores'] ?? null;
+        $rawBlocks = $attributes['blocks'] ?? [];
+
+        Assert::integer($index);
+        Assert::string($markdown);
+        Assert::isArray($rawImages);
+        Assert::nullOrIsArray($rawDimensions);
+        Assert::isArray($rawTables);
+        Assert::isArray($hyperlinks);
+        Assert::allString($hyperlinks);
+        Assert::nullOrString($header);
+        Assert::nullOrString($footer);
+        Assert::nullOrIsArray($rawConfidenceScores);
+        Assert::isArray($rawBlocks);
+
+        $images = \array_map(
+            static function (mixed $image): Image {
+                Assert::isArray($image);
+
+                return Image::from($image);
+            },
+            $rawImages,
+        );
+
+        $tables = \array_map(
+            static function (mixed $table): Table {
+                Assert::isArray($table);
+
+                return Table::from($table);
+            },
+            $rawTables,
+        );
+
+        $blocks = \array_map(
+            static function (mixed $block): Block {
+                Assert::isArray($block);
+
+                return Block::from($block);
+            },
+            $rawBlocks,
+        );
+
+        return new self(
+            $index,
+            $markdown,
+            $images,
+            null !== $rawDimensions ? Dimensions::from($rawDimensions) : null,
+            $tables,
+            $hyperlinks,
+            $header,
+            $footer,
+            null !== $rawConfidenceScores ? ConfidenceScores::from($rawConfidenceScores) : null,
+            $blocks,
+        );
+    }
+}

--- a/packages/mistral/src/Responses/Ocr/Page.php
+++ b/packages/mistral/src/Responses/Ocr/Page.php
@@ -44,8 +44,8 @@ final readonly class Page
     {
         $index = $attributes['index'];
         $markdown = $attributes['markdown'];
-        $rawImages = $attributes['images'];
-        $rawDimensions = $attributes['dimensions'];
+        $rawImages = $attributes['images'] ?? [];
+        $rawDimensions = $attributes['dimensions'] ?? null;
         $rawTables = $attributes['tables'] ?? [];
         $hyperlinks = $attributes['hyperlinks'] ?? [];
         $header = $attributes['header'] ?? null;

--- a/packages/mistral/src/Responses/Ocr/ProcessResponse.php
+++ b/packages/mistral/src/Responses/Ocr/ProcessResponse.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Modelflow AI package.
+ *
+ * (c) Johannes Wachter <johannes@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ModelflowAi\Mistral\Responses\Ocr;
+
+use ModelflowAi\ApiClient\Responses\MetaInformation;
+use Webmozart\Assert\Assert;
+
+final readonly class ProcessResponse
+{
+    /**
+     * @param Page[] $pages
+     */
+    private function __construct(
+        public array $pages,
+        public string $model,
+        public UsageInfo $usageInfo,
+        public ?string $documentAnnotation,
+        public MetaInformation $meta,
+    ) {
+    }
+
+    /**
+     * @param array<mixed> $attributes
+     */
+    public static function from(array $attributes, MetaInformation $meta): self
+    {
+        $rawPages = $attributes['pages'];
+        $model = $attributes['model'];
+        $rawUsageInfo = $attributes['usage_info'];
+        $documentAnnotation = $attributes['document_annotation'] ?? null;
+
+        Assert::isArray($rawPages);
+        Assert::string($model);
+        Assert::isArray($rawUsageInfo);
+        Assert::nullOrString($documentAnnotation);
+
+        $pages = \array_map(
+            static function (mixed $page): Page {
+                Assert::isArray($page);
+
+                return Page::from($page);
+            },
+            $rawPages,
+        );
+
+        return new self(
+            $pages,
+            $model,
+            UsageInfo::from($rawUsageInfo),
+            $documentAnnotation,
+            $meta,
+        );
+    }
+}

--- a/packages/mistral/src/Responses/Ocr/Table.php
+++ b/packages/mistral/src/Responses/Ocr/Table.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Modelflow AI package.
+ *
+ * (c) Johannes Wachter <johannes@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ModelflowAi\Mistral\Responses\Ocr;
+
+use Webmozart\Assert\Assert;
+
+final readonly class Table
+{
+    /**
+     * @param ConfidenceScore[] $wordConfidenceScores
+     */
+    private function __construct(
+        public string $id,
+        public string $content,
+        public string $format,
+        public array $wordConfidenceScores,
+    ) {
+    }
+
+    /**
+     * @param array<mixed> $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        $id = $attributes['id'];
+        $content = $attributes['content'];
+        $format = $attributes['format'];
+        $rawWordConfidenceScores = $attributes['word_confidence_scores'] ?? [];
+
+        Assert::string($id);
+        Assert::string($content);
+        Assert::string($format);
+        Assert::isArray($rawWordConfidenceScores);
+
+        $wordConfidenceScores = \array_map(
+            static function (mixed $score): ConfidenceScore {
+                Assert::isArray($score);
+
+                return ConfidenceScore::from($score);
+            },
+            $rawWordConfidenceScores,
+        );
+
+        return new self(
+            $id,
+            $content,
+            $format,
+            $wordConfidenceScores,
+        );
+    }
+}

--- a/packages/mistral/src/Responses/Ocr/UsageInfo.php
+++ b/packages/mistral/src/Responses/Ocr/UsageInfo.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Modelflow AI package.
+ *
+ * (c) Johannes Wachter <johannes@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ModelflowAi\Mistral\Responses\Ocr;
+
+use Webmozart\Assert\Assert;
+
+final readonly class UsageInfo
+{
+    private function __construct(
+        public int $pagesProcessed,
+        public ?int $docSizeBytes,
+    ) {
+    }
+
+    /**
+     * @param array<mixed> $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        $pagesProcessed = $attributes['pages_processed'];
+        $docSizeBytes = $attributes['doc_size_bytes'] ?? null;
+
+        Assert::integer($pagesProcessed);
+        Assert::nullOrInteger($docSizeBytes);
+
+        return new self(
+            $pagesProcessed,
+            $docSizeBytes,
+        );
+    }
+}

--- a/packages/mistral/tests/Unit/ClientTest.php
+++ b/packages/mistral/tests/Unit/ClientTest.php
@@ -18,6 +18,7 @@ use ModelflowAi\Mistral\Client;
 use ModelflowAi\Mistral\ClientInterface;
 use ModelflowAi\Mistral\Resources\Chat;
 use ModelflowAi\Mistral\Resources\Embeddings;
+use ModelflowAi\Mistral\Resources\Ocr;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
@@ -50,6 +51,14 @@ final class ClientTest extends TestCase
 
         $embeddings = $client->embeddings();
         $this->assertInstanceOf(Embeddings::class, $embeddings);
+    }
+
+    public function testOcr(): void
+    {
+        $client = $this->createInstance($this->transport->reveal());
+
+        $ocr = $client->ocr();
+        $this->assertInstanceOf(Ocr::class, $ocr);
     }
 
     private function createInstance(TransportInterface $transport): ClientInterface

--- a/packages/mistral/tests/Unit/Resources/OcrTest.php
+++ b/packages/mistral/tests/Unit/Resources/OcrTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Modelflow AI package.
+ *
+ * (c) Johannes Wachter <johannes@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ModelflowAi\Mistral\Tests\Unit\Resources;
+
+use ModelflowAi\ApiClient\Responses\MetaInformation;
+use ModelflowAi\ApiClient\Transport\Enums\Method;
+use ModelflowAi\ApiClient\Transport\Payload;
+use ModelflowAi\ApiClient\Transport\Response\ObjectResponse;
+use ModelflowAi\ApiClient\Transport\TransportInterface;
+use ModelflowAi\Mistral\Model;
+use ModelflowAi\Mistral\Resources\Ocr;
+use ModelflowAi\Mistral\Resources\OcrInterface;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+
+final class OcrTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @var ObjectProphecy<TransportInterface>
+     */
+    private ObjectProphecy $transport;
+
+    protected function setUp(): void
+    {
+        $this->transport = $this->prophesize(TransportInterface::class);
+    }
+
+    public function testProcess(): void
+    {
+        $response = new ObjectResponse([
+            'pages' => [
+                [
+                    'index' => 0,
+                    'markdown' => '# Invoice',
+                    'images' => [],
+                    'dimensions' => null,
+                    'blocks' => [
+                        [
+                            'type' => 'title',
+                            'top_left_x' => 10,
+                            'top_left_y' => 20,
+                            'bottom_right_x' => 120,
+                            'bottom_right_y' => 60,
+                            'content' => 'Invoice',
+                        ],
+                    ],
+                ],
+            ],
+            'model' => Model::OCR_4->value,
+            'usage_info' => [
+                'pages_processed' => 1,
+                'doc_size_bytes' => 1234,
+            ],
+        ], MetaInformation::from([]));
+
+        $this->transport->requestObject(
+            Argument::that(static fn (Payload $payload) => 'ocr' === $payload->resourceUri->uri
+                && Method::POST === $payload->method
+                && [
+                    'model' => Model::OCR_4->value,
+                    'document' => [
+                        'type' => 'document_url',
+                        'document_url' => 'https://example.com/invoice.pdf',
+                        'document_name' => 'invoice.pdf',
+                    ],
+                    'pages' => '0,1',
+                    'include_blocks' => true,
+                    'include_image_base64' => true,
+                    'table_format' => 'markdown',
+                ] === $payload->parameters),
+        )->willReturn($response);
+
+        $ocr = $this->createInstance($this->transport->reveal());
+
+        $result = $ocr->process([
+            'model' => Model::OCR_4->value,
+            'document' => [
+                'type' => 'document_url',
+                'document_url' => 'https://example.com/invoice.pdf',
+                'document_name' => 'invoice.pdf',
+            ],
+            'pages' => '0,1',
+            'include_blocks' => true,
+            'include_image_base64' => true,
+            'table_format' => 'markdown',
+        ]);
+
+        $this->assertSame(Model::OCR_4->value, $result->model);
+        $this->assertSame('title', $result->pages[0]->blocks[0]->type);
+    }
+
+    public function testProcessUsesDefaultModel(): void
+    {
+        $response = new ObjectResponse([
+            'pages' => [
+                [
+                    'index' => 0,
+                    'markdown' => '# Invoice',
+                    'images' => [],
+                    'dimensions' => null,
+                ],
+            ],
+            'model' => Model::OCR->value,
+            'usage_info' => [
+                'pages_processed' => 1,
+            ],
+        ], MetaInformation::from([]));
+
+        $this->transport->requestObject(
+            Argument::that(static fn (Payload $payload) => Model::OCR->value === $payload->parameters['model']),
+        )->willReturn($response);
+
+        $ocr = $this->createInstance($this->transport->reveal());
+
+        $result = $ocr->process([
+            'document' => [
+                'document_url' => 'https://example.com/invoice.pdf',
+            ],
+        ]);
+
+        $this->assertSame(Model::OCR->value, $result->model);
+    }
+
+    public function testProcessMissingDocumentSource(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $ocr = $this->createInstance($this->transport->reveal());
+
+        $ocr->process(['document' => []]);
+    }
+
+    private function createInstance(TransportInterface $transport): OcrInterface
+    {
+        return new Ocr($transport);
+    }
+}

--- a/packages/mistral/tests/Unit/Resources/OcrTest.php
+++ b/packages/mistral/tests/Unit/Resources/OcrTest.php
@@ -136,6 +136,44 @@ final class OcrTest extends TestCase
         $this->assertSame(Model::OCR->value, $result->model);
     }
 
+    public function testProcessWritesDetectedDocumentType(): void
+    {
+        $response = new ObjectResponse([
+            'pages' => [
+                [
+                    'index' => 0,
+                    'markdown' => '# Invoice',
+                    'images' => [],
+                    'dimensions' => null,
+                ],
+            ],
+            'model' => Model::OCR->value,
+            'usage_info' => [
+                'pages_processed' => 1,
+            ],
+        ], MetaInformation::from([]));
+
+        $capturedType = null;
+        $this->transport->requestObject(
+            Argument::that(static function (Payload $payload) use (&$capturedType): bool {
+                $document = $payload->parameters['document'] ?? null;
+                $capturedType = \is_array($document) ? ($document['type'] ?? null) : null;
+
+                return true;
+            }),
+        )->willReturn($response);
+
+        $ocr = $this->createInstance($this->transport->reveal());
+
+        $ocr->process([
+            'document' => [
+                'document_url' => 'https://example.com/invoice.pdf',
+            ],
+        ]);
+
+        $this->assertSame('document_url', $capturedType);
+    }
+
     public function testProcessMissingDocumentSource(): void
     {
         $this->expectException(\InvalidArgumentException::class);

--- a/packages/mistral/tests/Unit/Responses/Ocr/ProcessResponseTest.php
+++ b/packages/mistral/tests/Unit/Responses/Ocr/ProcessResponseTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Modelflow AI package.
+ *
+ * (c) Johannes Wachter <johannes@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ModelflowAi\Mistral\Tests\Unit\Responses\Ocr;
+
+use ModelflowAi\ApiClient\Responses\MetaInformation;
+use ModelflowAi\Mistral\Model;
+use ModelflowAi\Mistral\Responses\Ocr\ProcessResponse;
+use PHPUnit\Framework\TestCase;
+
+final class ProcessResponseTest extends TestCase
+{
+    public function testFrom(): void
+    {
+        $instance = ProcessResponse::from([
+            'pages' => [
+                [
+                    'index' => 0,
+                    'markdown' => '# Invoice',
+                    'images' => [
+                        [
+                            'id' => 'img-0.jpeg',
+                            'top_left_x' => 10,
+                            'top_left_y' => 20,
+                            'bottom_right_x' => 30,
+                            'bottom_right_y' => 40,
+                            'image_base64' => 'data:image/jpeg;base64,test',
+                        ],
+                    ],
+                    'dimensions' => [
+                        'dpi' => 200,
+                        'height' => 2200,
+                        'width' => 1700,
+                    ],
+                    'tables' => [
+                        [
+                            'id' => 'tbl-0',
+                            'content' => '| A | B |',
+                            'format' => 'markdown',
+                            'word_confidence_scores' => [
+                                [
+                                    'text' => 'A',
+                                    'confidence' => 0.98,
+                                    'start_index' => 1,
+                                ],
+                            ],
+                        ],
+                    ],
+                    'hyperlinks' => ['https://example.com'],
+                    'header' => 'Header',
+                    'footer' => 'Footer',
+                    'confidence_scores' => [
+                        'word_confidence_scores' => [
+                            [
+                                'text' => 'Invoice',
+                                'confidence' => 0.99,
+                                'start_index' => 0,
+                            ],
+                        ],
+                        'average_page_confidence_score' => 0.99,
+                        'minimum_page_confidence_score' => 0.98,
+                    ],
+                    'blocks' => [
+                        [
+                            'type' => 'table',
+                            'top_left_x' => 10,
+                            'top_left_y' => 20,
+                            'bottom_right_x' => 120,
+                            'bottom_right_y' => 60,
+                            'content' => '| A | B |',
+                            'table_id' => 'tbl-0',
+                        ],
+                    ],
+                ],
+            ],
+            'model' => Model::OCR_4->value,
+            'usage_info' => [
+                'pages_processed' => 1,
+                'doc_size_bytes' => 1234,
+            ],
+            'document_annotation' => '{"invoice":true}',
+        ], MetaInformation::from([]));
+
+        $this->assertSame(Model::OCR_4->value, $instance->model);
+        $this->assertCount(1, $instance->pages);
+        $this->assertSame('# Invoice', $instance->pages[0]->markdown);
+        $this->assertSame('img-0.jpeg', $instance->pages[0]->images[0]->id);
+        $this->assertSame(200, $instance->pages[0]->dimensions?->dpi);
+        $this->assertSame('tbl-0', $instance->pages[0]->tables[0]->id);
+        $this->assertSame('https://example.com', $instance->pages[0]->hyperlinks[0]);
+        $this->assertSame('Header', $instance->pages[0]->header);
+        $this->assertSame('Footer', $instance->pages[0]->footer);
+        $this->assertSame(0.99, $instance->pages[0]->confidenceScores?->averagePageConfidenceScore);
+        $this->assertSame('table', $instance->pages[0]->blocks[0]->type);
+        $this->assertSame(120, $instance->pages[0]->blocks[0]->bottomRightX);
+        $this->assertSame('tbl-0', $instance->pages[0]->blocks[0]->tableId);
+        $this->assertSame(1, $instance->usageInfo->pagesProcessed);
+        $this->assertSame(1234, $instance->usageInfo->docSizeBytes);
+        $this->assertSame('{"invoice":true}', $instance->documentAnnotation);
+        $this->assertSame([], $instance->meta->headers);
+    }
+}

--- a/packages/mistral/tests/Unit/Responses/Ocr/ProcessResponseTest.php
+++ b/packages/mistral/tests/Unit/Responses/Ocr/ProcessResponseTest.php
@@ -109,4 +109,64 @@ final class ProcessResponseTest extends TestCase
         $this->assertSame('{"invoice":true}', $instance->documentAnnotation);
         $this->assertSame([], $instance->meta->headers);
     }
+
+    public function testFromAcceptsIntegerConfidenceScores(): void
+    {
+        $instance = ProcessResponse::from([
+            'pages' => [
+                [
+                    'index' => 0,
+                    'markdown' => '# Invoice',
+                    'images' => [],
+                    'dimensions' => null,
+                    'confidence_scores' => [
+                        'word_confidence_scores' => [
+                            [
+                                'text' => 'Invoice',
+                                'confidence' => 1,
+                                'start_index' => 0,
+                            ],
+                        ],
+                        'average_page_confidence_score' => 1,
+                        'minimum_page_confidence_score' => 0,
+                    ],
+                ],
+            ],
+            'model' => Model::OCR->value,
+            'usage_info' => [
+                'pages_processed' => 1,
+            ],
+        ], MetaInformation::from([]));
+
+        $confidenceScores = $instance->pages[0]->confidenceScores;
+        $this->assertNotNull($confidenceScores);
+        $this->assertSame(1.0, $confidenceScores->averagePageConfidenceScore);
+        $this->assertSame(0.0, $confidenceScores->minimumPageConfidenceScore);
+        $this->assertSame(1.0, $confidenceScores->wordConfidenceScores[0]->confidence);
+    }
+
+    public function testFromHandlesMissingOptionalPageAndImageKeys(): void
+    {
+        $instance = ProcessResponse::from([
+            'pages' => [
+                [
+                    'index' => 0,
+                    'markdown' => '# Invoice',
+                    'images' => [
+                        [
+                            'id' => 'img-0.jpeg',
+                        ],
+                    ],
+                ],
+            ],
+            'model' => Model::OCR->value,
+            'usage_info' => [
+                'pages_processed' => 1,
+            ],
+        ], MetaInformation::from([]));
+
+        $this->assertNull($instance->pages[0]->dimensions);
+        $this->assertNull($instance->pages[0]->images[0]->topLeftX);
+        $this->assertNull($instance->pages[0]->images[0]->bottomRightY);
+    }
 }


### PR DESCRIPTION
## What changed

- Adds an OCR resource to the Mistral client for the `ocr` endpoint.
- Adds `Model::OCR` (`mistral-ocr-latest`) and `Model::OCR_4` (`mistral-ocr-4-0`).
- Adds typed OCR response objects for pages, images, dimensions, tables, confidence scores, usage info, and OCR 4 blocks.
- Adds OCR examples for basic Markdown extraction and OCR 4 block extraction.
- Adds unit coverage for `Client::ocr()`, OCR request payload mapping, default model behavior, validation, and OCR 4 response block mapping.
- Fixes an unrelated highest-deps PHPStan issue in the Google Gemini adapter that blocked the monorepo GitHub Actions matrix.

## Why

Downstream consumers need first-class Mistral OCR support instead of carrying a Composer patch in application repositories. OCR 4 block extraction is included so clients can consume structured page regions from the API.

## Validation

Ran locally in `packages/mistral`:

- `composer fix`
- `composer lint`
- `composer test`

Ran locally in `packages/google-gemini-adapter` for the CI fix:

- `composer fix`
- `composer lint`
- `composer test`

GitHub Actions:

- 86/86 checks passing on this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OCR support to the Mistral client, including a new OCR endpoint and response handling.
  * Added OCR model options and structured OCR result objects for pages, tables, images, blocks, confidence scores, and usage details.
  * Added CLI OCR examples for processing local files or document URLs, with optional page selection and richer extracted output.

* **Bug Fixes**
  * Tightened response configuration handling for Gemini so schema-related output is only applied when the response format is valid.

* **Tests**
  * Added unit coverage for OCR client access, OCR processing, and OCR response parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->