### PR TITLE
Add thought signature support for Google Gemini tool calls

### DIFF
--- a/packages/chat/src/Request/Message/ToolCallsPart.php
+++ b/packages/chat/src/Request/Message/ToolCallsPart.php
@@ -39,14 +39,22 @@ readonly class ToolCallsPart extends MessagePart
     {
         $message['content'] = '';
         $message['tool_calls'] = \array_map(
-            static fn (AIChatToolCall $tool) => [
-                'id' => $tool->id,
-                'type' => $tool->type->value,
-                'function' => [
-                    'name' => $tool->name,
-                    'arguments' => (string) \json_encode($tool->arguments),
-                ],
-            ],
+            static function (AIChatToolCall $tool): array {
+                $toolCall = [
+                    'id' => $tool->id,
+                    'type' => $tool->type->value,
+                    'function' => [
+                        'name' => $tool->name,
+                        'arguments' => (string) \json_encode($tool->arguments),
+                    ],
+                ];
+
+                if (null !== $tool->signature) {
+                    $toolCall['signature'] = $tool->signature;
+                }
+
+                return $toolCall;
+            },
             $this->toolCalls,
         );
 

--- a/packages/chat/src/Response/AIChatToolCall.php
+++ b/packages/chat/src/Response/AIChatToolCall.php
@@ -19,12 +19,15 @@ readonly class AIChatToolCall
 {
     /**
      * @param array<string, mixed> $arguments
+     * @param string|null $signature Provider scoped signature guarding this tool call when it is replayed
+     *                               in a follow-up request. Currently only Google Gemini emits one.
      */
     public function __construct(
         public ToolTypeEnum $type,
         public string $id,
         public string $name,
         public array $arguments,
+        public ?string $signature = null,
     ) {
     }
 }

--- a/packages/chat/tests/Unit/Request/Message/ToolCallsPartTest.php
+++ b/packages/chat/tests/Unit/Request/Message/ToolCallsPartTest.php
@@ -59,4 +59,34 @@ class ToolCallsPartTest extends TestCase
 
         $this->assertSame($expectedResult, $toolCallsPart->enhanceMessage($result));
     }
+
+    public function testEnhanceMessageWithSignature(): void
+    {
+        $toolCalls = [
+            new AIChatToolCall(ToolTypeEnum::FUNCTION, '123-123-123', 'name', ['test' => 'test'], 'signature-123'),
+        ];
+        $toolCallsPart = new ToolCallsPart($toolCalls);
+
+        $result = [
+            'role' => AIChatMessageRoleEnum::USER->value,
+            'content' => '',
+        ];
+        $expectedResult = [
+            'role' => AIChatMessageRoleEnum::USER->value,
+            'content' => '',
+            'tool_calls' => [
+                [
+                    'id' => '123-123-123',
+                    'type' => ToolTypeEnum::FUNCTION->value,
+                    'function' => [
+                        'name' => 'name',
+                        'arguments' => '{"test":"test"}',
+                    ],
+                    'signature' => 'signature-123',
+                ],
+            ],
+        ];
+
+        $this->assertSame($expectedResult, $toolCallsPart->enhanceMessage($result));
+    }
 }

--- a/packages/chat/tests/Unit/Response/AIChatToolCallTest.php
+++ b/packages/chat/tests/Unit/Response/AIChatToolCallTest.php
@@ -46,4 +46,18 @@ class AIChatToolCallTest extends TestCase
 
         $this->assertSame(['test' => 'test'], $message->arguments);
     }
+
+    public function testSignatureDefaultsToNull(): void
+    {
+        $message = new AIChatToolCall(ToolTypeEnum::FUNCTION, '123-123-123', 'name', ['test' => 'test']);
+
+        $this->assertNull($message->signature);
+    }
+
+    public function testSignature(): void
+    {
+        $message = new AIChatToolCall(ToolTypeEnum::FUNCTION, '123-123-123', 'name', ['test' => 'test'], 'signature-123');
+
+        $this->assertSame('signature-123', $message->signature);
+    }
 }

--- a/packages/google-gemini-adapter/composer.json
+++ b/packages/google-gemini-adapter/composer.json
@@ -26,7 +26,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "google-gemini-php/client": "^2.0",
+        "google-gemini-php/client": "^2.5",
         "php-http/discovery": "^1.0",
         "psr/http-client-implementation": "^1.0",
         "psr/http-client": "^1.0",

--- a/packages/google-gemini-adapter/composer.lock
+++ b/packages/google-gemini-adapter/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "00c7ef46e6f62868f8f963e52b95eafa",
+    "content-hash": "318b3abce160e9c83b919c1445379957",
     "packages": [
         {
             "name": "google-gemini-php/client",

--- a/packages/google-gemini-adapter/src/Chat/GoogleGeminiChatAdapter.php
+++ b/packages/google-gemini-adapter/src/Chat/GoogleGeminiChatAdapter.php
@@ -90,11 +90,16 @@ final readonly class GoogleGeminiChatAdapter implements AIChatAdapterInterface, 
                     $parts[] = new Part(inlineData: new Blob(MimeType::from($part->mimeType), $part->content));
                 } elseif ($part instanceof ToolCallsPart) {
                     foreach ($part->toolCalls as $toolCall) {
-                        $parts[] = new Part(functionCall: new FunctionCall(
-                            name: $toolCall->name,
-                            args: $toolCall->arguments,
-                            id: '' !== $toolCall->id ? $toolCall->id : null,
-                        ));
+                        // Gemini rejects a follow-up request when the thought signature of a function call
+                        // is not sent back with it.
+                        $parts[] = new Part(
+                            functionCall: new FunctionCall(
+                                name: $toolCall->name,
+                                args: $toolCall->arguments,
+                                id: '' !== $toolCall->id ? $toolCall->id : null,
+                            ),
+                            thoughtSignature: $toolCall->signature,
+                        );
                     }
                 } elseif ($part instanceof ToolCallPart) {
                     $parts[] = new Part(functionResponse: new FunctionResponse(
@@ -261,6 +266,9 @@ final readonly class GoogleGeminiChatAdapter implements AIChatAdapterInterface, 
      * Gemini does not always return an id for a function call; fall back to the function name,
      * which is also what the API uses to correlate the matching functionResponse.
      *
+     * The thought signature of the part is kept because Gemini requires it to be sent back with the
+     * function call in a follow-up request.
+     *
      * @return AIChatToolCall[]
      */
     private function extractToolCalls(GenerateContentResponse $result): array
@@ -277,6 +285,7 @@ final readonly class GoogleGeminiChatAdapter implements AIChatAdapterInterface, 
                     $part->functionCall->id ?? $part->functionCall->name,
                     $part->functionCall->name,
                     $part->functionCall->args,
+                    $part->thoughtSignature,
                 );
             }
 

--- a/packages/google-gemini-adapter/tests/Unit/Chat/GoogleGeminiChatAdapterTest.php
+++ b/packages/google-gemini-adapter/tests/Unit/Chat/GoogleGeminiChatAdapterTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ModelflowAi\GoogleGeminiAdapter\Tests\Unit\Chat;
 
 use Gemini\Contracts\ClientContract;
+use Gemini\Data\Content;
 use Gemini\Data\FunctionCall;
 use Gemini\Data\FunctionResponse;
 use Gemini\Data\GenerationConfig;
@@ -393,6 +394,116 @@ final class GoogleGeminiChatAdapterTest extends TestCase
                     && $args[0] instanceof Tool
                     && null !== $args[0]->functionDeclarations
                     && 'get_weather' === $args[0]->functionDeclarations[0]->name,
+            );
+    }
+
+    public function testHandleRequestKeepsThoughtSignatureOfToolCall(): void
+    {
+        $client = new ClientFake([
+            GenerateContentResponse::fake([
+                'candidates' => [
+                    [
+                        'content' => [
+                            'parts' => [
+                                ['text' => ''],
+                                [
+                                    'functionCall' => [
+                                        'name' => 'get_weather',
+                                        'args' => ['location' => 'Berlin'],
+                                    ],
+                                    'thoughtSignature' => 'signature-123',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ]),
+        ]);
+
+        $request = new AIChatRequest(
+            new AIChatMessageCollection(
+                new AIChatMessage(AIChatMessageRoleEnum::USER, 'What is the weather in Berlin?'),
+            ),
+            new CriteriaCollection(),
+            [],
+            [
+                new ToolInfo(
+                    ToolTypeEnum::FUNCTION,
+                    'get_weather',
+                    'Get the current weather',
+                    [new Parameter('location', 'string', 'The location')],
+                    [new Parameter('location', 'string', 'The location')],
+                ),
+            ],
+            [],
+            static fn () => null,
+        );
+
+        $adapter = new GoogleGeminiChatAdapter($client, ModelType::GEMINI_FLASH->value);
+        $result = $adapter->handleRequest($request);
+
+        $toolCalls = $result->getMessage()->toolCalls;
+        $this->assertNotNull($toolCalls);
+        $this->assertSame('signature-123', $toolCalls[0]->signature);
+    }
+
+    public function testHandleRequestSendsThoughtSignatureBackWithToolCall(): void
+    {
+        $client = new ClientFake([
+            GenerateContentResponse::fake([
+                'candidates' => [
+                    [
+                        'content' => [
+                            'parts' => [
+                                [
+                                    'text' => 'It is sunny.',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ]),
+        ]);
+
+        $request = new AIChatRequest(
+            new AIChatMessageCollection(
+                new AIChatMessage(AIChatMessageRoleEnum::USER, 'What is the weather in Berlin?'),
+                new AIChatMessage(
+                    AIChatMessageRoleEnum::ASSISTANT,
+                    ToolCallsPart::create([
+                        new AIChatToolCall(
+                            ToolTypeEnum::FUNCTION,
+                            'call_1',
+                            'get_weather',
+                            ['location' => 'Berlin'],
+                            'signature-123',
+                        ),
+                    ]),
+                ),
+                new AIChatMessage(
+                    AIChatMessageRoleEnum::TOOL,
+                    ToolCallPart::create('call_1', 'get_weather', '{"temperature":21}'),
+                ),
+            ),
+            new CriteriaCollection(),
+            [],
+            [],
+            [],
+            static fn () => null,
+        );
+
+        $adapter = new GoogleGeminiChatAdapter($client, ModelType::GEMINI_FLASH->value);
+        $adapter->handleRequest($request);
+
+        $client->generativeModel(ModelType::GEMINI_FLASH->value)
+            ->assertSent(
+                static function (string $method, array $args): bool {
+                    $content = $args[1] ?? null;
+
+                    return 'generateContent' === $method
+                        && $content instanceof Content
+                        && 'signature-123' === $content->parts[0]->thoughtSignature;
+                },
             );
     }
 


### PR DESCRIPTION
## Problem

Gemini 3 models return a thought signature on the `functionCall` part of a tool call and require it to be sent back with that tool call in the follow-up request. The adapter dropped it, so every tool roundtrip failed with:

> Function call is missing a thought_signature in functionCall parts. This is required for tools to work correctly, and missing thought_signature may lead to degraded model performance.

The first turn works, the request carrying the tool result is rejected by the API.

## Solution

`AIChatToolCall` gets an optional `signature`, named after `Symfony\AI\Platform\Result\ToolCall::$signature` which covers the same concept, so consumers of both libraries use one word for it.

The Google Gemini adapter stores the thought signature of the `functionCall` part in it when reading the response and restores it on the `Part` when the tool call is sent back. Streaming is covered as well because it uses the same extraction.

`ToolCallsPart::enhanceMessage()` serializes the signature only when there is one, so existing payloads stay unchanged.

## Backwards compatibility

The new constructor argument is optional and defaults to `null`, so no existing call site breaks. Tests of the anthropic, mistral and openai adapters were run against the updated chat package to confirm this.

## Tests

- `packages/chat`: 277 tests green, coverage for the signature property and its serialization
- `packages/google-gemini-adapter`: 26 tests green, two new tests covering that the signature is read from the response and sent back with the tool call
- `composer lint` green in both packages

Not covered: a roundtrip against the live Google API, the tests use `ClientFake`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preserved Gemini thought signatures across tool-call follow-ups, improving compatibility with multi-step interactions.
  * Tool calls can now optionally carry provider-specific signature metadata.

* **Bug Fixes**
  * Prevented signature metadata from being lost when tool calls are converted between chat messages and Gemini requests.

* **Tests**
  * Added coverage for signature handling, including default, response, and follow-up request scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->