### PR TITLE
Rename renamed rector rule in completion and gemini adapter config

### DIFF
--- a/packages/completion/rector.php
+++ b/packages/completion/rector.php
@@ -12,14 +12,14 @@ declare(strict_types=1);
  */
 
 use Rector\Config\RectorConfig;
-use Rector\Php81\Rector\Array_\FirstClassCallableRector;
+use Rector\Php81\Rector\Array_\ArrayToFirstClassCallableRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $config = require __DIR__ . '/../../rector.php';
     $config($rectorConfig, __DIR__);
 
     $rectorConfig->skip([
-        FirstClassCallableRector::class => [
+        ArrayToFirstClassCallableRector::class => [
             __DIR__ . '/tests/Unit/ToolInfo/ToolExecutorTest.php',
         ],
     ]);

--- a/packages/google-gemini-adapter/rector.php
+++ b/packages/google-gemini-adapter/rector.php
@@ -12,14 +12,14 @@ declare(strict_types=1);
  */
 
 use Rector\Config\RectorConfig;
-use Rector\Php81\Rector\Array_\FirstClassCallableRector;
+use Rector\Php81\Rector\Array_\ArrayToFirstClassCallableRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $config = require __DIR__ . '/../../rector.php';
     $config($rectorConfig, __DIR__);
 
     $rectorConfig->skip([
-        FirstClassCallableRector::class => [
+        ArrayToFirstClassCallableRector::class => [
             __DIR__ . '/tests/Unit/Chat/GoogleGeminiChatAdapterTest.php',
         ],
     ]);


### PR DESCRIPTION
## Problem

Rector renamed `FirstClassCallableRector` to `ArrayToFirstClassCallableRector` and rejects a skip entry that points to a rule which does not exist:

> [ERROR] These rules from "$rectorConfig->skip()" do not exist - remove them or fix their names:
>   * Rector\Php81\Rector\Array_\FirstClassCallableRector

That fails the `Lint true` job of every affected package on the newest rector, independent of the code under test.

## Solution

Both remaining configs use the new name now, the other five packages were migrated already.

## Tests

`composer lint` green in `packages/completion` and `packages/google-gemini-adapter` (rector 2.4.5 locally).