### PR TITLE
Send an empty object for tools without parameters to Anthropic

### DIFF
--- a/packages/anthropic-adapter/src/Chat/ToolFormatter.php
+++ b/packages/anthropic-adapter/src/Chat/ToolFormatter.php
@@ -24,7 +24,7 @@ final class ToolFormatter
      *     description: string,
      *     input_schema: array{
      *         type: string,
-     *         properties: array<string, array<string, mixed>>,
+     *         properties: array<string, array<string, mixed>>|\stdClass,
      *         required?: string[],
      *     },
      * }
@@ -47,7 +47,9 @@ final class ToolFormatter
             'description' => $tool->description,
             'input_schema' => [
                 'type' => 'object',
-                'properties' => $parameters,
+                // a tool without parameters has to send an empty object, an empty array would be
+                // encoded as [] and is rejected by the api
+                'properties' => [] !== $parameters ? $parameters : new \stdClass(),
                 'required' => $requiredParameters,
             ],
         ];
@@ -61,7 +63,7 @@ final class ToolFormatter
      *     description: string,
      *     input_schema: array{
      *         type: string,
-     *         properties: array<string, array<string, mixed>>,
+     *         properties: array<string, array<string, mixed>>|\stdClass,
      *         required?: string[],
      *     },
      * }>
@@ -104,7 +106,7 @@ final class ToolFormatter
 
                 $items = [
                     'type' => 'object',
-                    'properties' => $properties,
+                    'properties' => [] !== $properties ? $properties : new \stdClass(),
                 ];
 
                 if ([] !== $parameter->required) {
@@ -126,7 +128,7 @@ final class ToolFormatter
                 $properties[$item->name] = self::formatParameter($item);
             }
 
-            $param['properties'] = $properties;
+            $param['properties'] = [] !== $properties ? $properties : new \stdClass();
 
             if ([] !== $parameter->required) {
                 $param['required'] = $parameter->required;

--- a/packages/anthropic-adapter/tests/Unit/Chat/ToolFormatterTest.php
+++ b/packages/anthropic-adapter/tests/Unit/Chat/ToolFormatterTest.php
@@ -253,4 +253,59 @@ class ToolFormatterTest extends TestCase
 
         $this->assertSame([], $formatted['input_schema']['required'] ?? []);
     }
+
+    public function testFormatToolWithoutParameters(): void
+    {
+        $tool = new ToolInfo(
+            type: ToolTypeEnum::FUNCTION,
+            name: 'test',
+            description: 'Test',
+            parameters: [],
+        );
+
+        $formatted = ToolFormatter::formatTool($tool);
+
+        // an empty array would be encoded as [] and is rejected by the api
+        $this->assertInstanceOf(\stdClass::class, $formatted['input_schema']['properties']);
+        $this->assertStringContainsString('"properties":{}', (string) \json_encode($formatted));
+    }
+
+    public function testFormatToolWithObjectParameterWithoutProperties(): void
+    {
+        $tool = new ToolInfo(
+            type: ToolTypeEnum::FUNCTION,
+            name: 'test',
+            description: 'Test',
+            parameters: [
+                new Parameter(name: 'data', type: 'object', description: 'Data object', itemsOrProperties: []),
+            ],
+        );
+
+        $formatted = ToolFormatter::formatTool($tool);
+
+        $properties = $formatted['input_schema']['properties'];
+        $this->assertIsArray($properties);
+        $data = $properties['data'];
+        $this->assertInstanceOf(\stdClass::class, $data['properties']);
+    }
+
+    public function testFormatToolWithArrayParameterWithoutItemProperties(): void
+    {
+        $tool = new ToolInfo(
+            type: ToolTypeEnum::FUNCTION,
+            name: 'test',
+            description: 'Test',
+            parameters: [
+                new Parameter(name: 'items', type: 'array', description: 'Items', itemsOrProperties: []),
+            ],
+        );
+
+        $formatted = ToolFormatter::formatTool($tool);
+
+        $properties = $formatted['input_schema']['properties'];
+        $this->assertIsArray($properties);
+        $items = $properties['items'];
+        $this->assertIsArray($items['items']);
+        $this->assertInstanceOf(\stdClass::class, $items['items']['properties']);
+    }
 }

--- a/packages/anthropic/src/Resources/MessagesInterface.php
+++ b/packages/anthropic/src/Resources/MessagesInterface.php
@@ -28,7 +28,7 @@ use ModelflowAi\Anthropic\Responses\Messages\CreateStreamedResponse;
  *     description: string,
  *     input_schema: array{
  *         type: string,
- *         properties: array<string, array<string, mixed>>,
+ *         properties: array<string, array<string, mixed>>|\stdClass,
  *         required?: string[],
  *     }
  * }


### PR DESCRIPTION
## Problem

A tool without parameters produces an empty PHP array for the `properties` of its input schema. `json_encode()` turns that into `[]`, and the Anthropic API rejects the request:

```
tools.3.custom.input_schema.properties: Input should be an object
```

One parameterless tool therefore breaks the whole chat request (seen in production on sulu.ai, HTTP 400 from `https://api.anthropic.com/v1/messages`).

Reproduction before the fix:

```
ToolInfo::fromJsonSchema(['function' => ['name' => 'ping', 'description' => 'Ping.']])
=> {"type":"object","properties":[],"required":[]}
```

## Fix

`ToolFormatter` emits an empty object instead of an empty array — for the input schema itself and for the two nested spots (`object` parameters and object `items` of an `array` parameter), which produce the same `[]` for a client-supplied schema with empty properties. The `Tool` phpstan shape of the messages resource allows `\stdClass` accordingly.

After:

```
{"type":"object","properties":{},"required":[]}
{"properties":{"payload":{"type":"object","description":"Anything.","properties":{}}}}
```

## Notes

- The Google Gemini formatter already handles this (it sends `null` for empty properties), so it needs no change.
- The OpenAI/Mistral/FireworksAI formatters have the same `[]` for a parameterless tool, but no failure has been reported for them and their `properties` shape is threaded through several declared array shapes; left untouched deliberately rather than changing a working payload shape. Happy to follow up if we want them aligned.

## Verification

- `composer test` in `packages/anthropic-adapter` (24 tests) and `packages/anthropic` (22 tests) — green
- `composer lint` in both packages (phpstan, php-cs-fixer, rector, composer validate) — green
- three new tests cover the parameterless tool plus the nested object and array-items cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected tool schema formatting so empty `properties` values are sent as JSON objects (`{}`) instead of arrays.
  * Improved compatibility for tools without parameters and object or array parameters without nested properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->