### PR TITLE
Send an empty object for tool calls without arguments

### DIFF
--- a/packages/anthropic-adapter/src/Chat/AnthropicChatAdapter.php
+++ b/packages/anthropic-adapter/src/Chat/AnthropicChatAdapter.php
@@ -137,7 +137,9 @@ final readonly class AnthropicChatAdapter implements AIChatAdapterInterface, Sup
                             'type' => 'tool_use',
                             'id' => $toolCall->id,
                             'name' => $toolCall->name,
-                            'input' => $toolCall->arguments,
+                            // a tool call without arguments has to send an empty object, an empty
+                            // array would be encoded as [] and is rejected by the api
+                            'input' => [] !== $toolCall->arguments ? $toolCall->arguments : new \stdClass(),
                         ];
                     }
                 } elseif ($part instanceof ToolCallPart) {

--- a/packages/anthropic-adapter/tests/Unit/Chat/AnthropicChatAdapterTest.php
+++ b/packages/anthropic-adapter/tests/Unit/Chat/AnthropicChatAdapterTest.php
@@ -19,11 +19,14 @@ use ModelflowAi\Anthropic\DataFixtures;
 use ModelflowAi\Anthropic\Model;
 use ModelflowAi\AnthropicAdapter\Chat\AnthropicChatAdapter;
 use ModelflowAi\ApiClient\Responses\MetaInformation;
+use ModelflowAi\ApiClient\Transport\Payload;
 use ModelflowAi\ApiClient\Transport\Response\ObjectResponse;
+use ModelflowAi\ApiClient\Transport\Response\TextResponse;
 use ModelflowAi\ApiClient\Transport\Testing\MockResponseMatcher;
 use ModelflowAi\ApiClient\Transport\Testing\MockTransport;
 use ModelflowAi\ApiClient\Transport\Testing\PartialPayload;
 use ModelflowAi\ApiClient\Transport\Testing\StreamedResponse;
+use ModelflowAi\ApiClient\Transport\TransportInterface;
 use ModelflowAi\Chat\Request\AIChatMessageCollection;
 use ModelflowAi\Chat\Request\AIChatRequest;
 use ModelflowAi\Chat\Request\AIChatStreamedRequest;
@@ -594,6 +597,62 @@ final class AnthropicChatAdapterTest extends TestCase
 
         $this->assertInstanceOf(AIChatResponse::class, $result);
         $this->assertSame(AIChatMessageRoleEnum::ASSISTANT, $result->getMessage()->role);
+    }
+
+    public function testHandleRequestWithToolCallsPartWithoutArguments(): void
+    {
+        // the payload is captured instead of being matched because two empty objects are never
+        // identical, which is what the response matcher compares
+        $transport = new class implements TransportInterface {
+            /**
+             * @var array<string, mixed>
+             */
+            public array $parameters = [];
+
+            public function requestText(Payload $payload): TextResponse
+            {
+                throw new \BadMethodCallException('Not expected to be called.');
+            }
+
+            public function requestObject(Payload $payload): ObjectResponse
+            {
+                $this->parameters = $payload->parameters;
+
+                return new ObjectResponse(DataFixtures::MESSAGES_CREATE_RESPONSE, MetaInformation::empty());
+            }
+
+            public function requestStream(Payload $payload, ?callable $decoder = null): \Iterator
+            {
+                throw new \BadMethodCallException('Not expected to be called.');
+            }
+        };
+
+        $toolCall = new AIChatToolCall(
+            ToolTypeEnum::FUNCTION,
+            'toolu_123',
+            'get_current_time',
+            [],
+        );
+
+        $request = new AIChatRequest(
+            new AIChatMessageCollection(
+                new AIChatMessage(AIChatMessageRoleEnum::USER, 'What time is it?'),
+                new AIChatMessage(AIChatMessageRoleEnum::ASSISTANT, ToolCallsPart::create([$toolCall])),
+                new AIChatMessage(AIChatMessageRoleEnum::USER, ToolCallPart::create('toolu_123', 'get_current_time', '11:07')),
+            ),
+            new CriteriaCollection(),
+            [],
+            [],
+            [],
+            static fn () => null,
+        );
+
+        $adapter = new AnthropicChatAdapter(new Client($transport), Model::CLAUDE_3_HAIKU->value, 100);
+        $adapter->handleRequest($request);
+
+        // a tool call without arguments is rejected with "messages.N.content.0.tool_use.input:
+        // Input should be an object" when it is sent as an empty array
+        $this->assertStringContainsString('"input":{}', (string) \json_encode($transport->parameters));
     }
 
     public function testHandleRequestWithToolCallPart(): void

--- a/packages/anthropic/src/Resources/Messages.php
+++ b/packages/anthropic/src/Resources/Messages.php
@@ -285,7 +285,11 @@ final readonly class Messages implements MessagesInterface
                     Assert::keyExists($content, 'name');
                     Assert::string($content['name']);
                     Assert::keyExists($content, 'input');
-                    Assert::isArray($content['input']);
+                    // a tool call without arguments is sent as an empty object, an empty array
+                    // would be encoded as [] and is rejected by the api
+                    if (!$content['input'] instanceof \stdClass) {
+                        Assert::isArray($content['input']);
+                    }
                 } elseif ('tool_result' === $content['type']) {
                     Assert::keyExists($content, 'tool_use_id');
                     Assert::string($content['tool_use_id']);

--- a/packages/anthropic/src/Resources/MessagesInterface.php
+++ b/packages/anthropic/src/Resources/MessagesInterface.php
@@ -20,8 +20,9 @@ use ModelflowAi\Anthropic\Responses\Messages\CreateStreamedResponse;
  * @phpstan-type TextMessage array{type: "text", text: string}
  * @phpstan-type ImageMessage array{type: "image", source: array{type: "base64", media_type: string, data: string}}
  * @phpstan-type ToolUseMessage array{type: "tool_use", id: string, name: string, input: array<string, mixed>}
+ * @phpstan-type ToolUseRequestMessage array{type: "tool_use", id: string, name: string, input: array<string, mixed>|\stdClass}
  * @phpstan-type ToolResultMessage array{type: "tool_result", tool_use_id: string, content: array<array{type: "text", text: string|null}>}
- * @phpstan-type MessageContent string|TextMessage|ImageMessage|ToolUseMessage|ToolResultMessage|array<TextMessage|ImageMessage|ToolUseMessage|ToolResultMessage>
+ * @phpstan-type MessageContent string|TextMessage|ImageMessage|ToolUseRequestMessage|ToolResultMessage|array<TextMessage|ImageMessage|ToolUseRequestMessage|ToolResultMessage>
  * @phpstan-type Message array{role: "system"|"assistant"|"user", content: MessageContent}
  * @phpstan-type Tool array{
  *     name: string,

--- a/packages/chat/src/Request/Message/ToolCallsPart.php
+++ b/packages/chat/src/Request/Message/ToolCallsPart.php
@@ -45,7 +45,9 @@ readonly class ToolCallsPart extends MessagePart
                     'type' => $tool->type->value,
                     'function' => [
                         'name' => $tool->name,
-                        'arguments' => (string) \json_encode($tool->arguments),
+                        // a tool call without arguments has to send an empty object, an empty
+                        // array would be encoded as []
+                        'arguments' => (string) \json_encode([] !== $tool->arguments ? $tool->arguments : new \stdClass()),
                     ],
                 ];
 

--- a/packages/chat/tests/Unit/Request/Message/ToolCallsPartTest.php
+++ b/packages/chat/tests/Unit/Request/Message/ToolCallsPartTest.php
@@ -60,6 +60,35 @@ class ToolCallsPartTest extends TestCase
         $this->assertSame($expectedResult, $toolCallsPart->enhanceMessage($result));
     }
 
+    public function testEnhanceMessageWithoutArguments(): void
+    {
+        $toolCalls = [
+            new AIChatToolCall(ToolTypeEnum::FUNCTION, '123-123-123', 'name', []),
+        ];
+        $toolCallsPart = new ToolCallsPart($toolCalls);
+
+        $result = [
+            'role' => AIChatMessageRoleEnum::USER->value,
+            'content' => '',
+        ];
+        $expectedResult = [
+            'role' => AIChatMessageRoleEnum::USER->value,
+            'content' => '',
+            'tool_calls' => [
+                [
+                    'id' => '123-123-123',
+                    'type' => ToolTypeEnum::FUNCTION->value,
+                    'function' => [
+                        'name' => 'name',
+                        'arguments' => '{}',
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertSame($expectedResult, $toolCallsPart->enhanceMessage($result));
+    }
+
     public function testEnhanceMessageWithSignature(): void
     {
         $toolCalls = [

--- a/packages/fireworksai-adapter/src/Chat/FireworksAiChatAdapter.php
+++ b/packages/fireworksai-adapter/src/Chat/FireworksAiChatAdapter.php
@@ -78,7 +78,9 @@ final readonly class FireworksAiChatAdapter implements AIChatAdapterInterface
                             'type' => $tool->type->value,
                             'function' => [
                                 'name' => $tool->name,
-                                'arguments' => (string) \json_encode($tool->arguments),
+                                // a tool call without arguments has to send an empty object, an
+                                // empty array would be encoded as []
+                                'arguments' => (string) \json_encode([] !== $tool->arguments ? $tool->arguments : new \stdClass()),
                             ],
                         ],
                         $part->toolCalls,

--- a/packages/mistral-adapter/src/Chat/MistralChatAdapter.php
+++ b/packages/mistral-adapter/src/Chat/MistralChatAdapter.php
@@ -75,7 +75,9 @@ final readonly class MistralChatAdapter implements AIChatAdapterInterface, Suppo
                             'type' => $tool->type->value,
                             'function' => [
                                 'name' => $tool->name,
-                                'arguments' => (string) \json_encode($tool->arguments),
+                                // a tool call without arguments has to send an empty object, an
+                                // empty array would be encoded as []
+                                'arguments' => (string) \json_encode([] !== $tool->arguments ? $tool->arguments : new \stdClass()),
                             ],
                         ],
                         $part->toolCalls,

--- a/packages/openai-adapter/src/Chat/OpenaiChatAdapter.php
+++ b/packages/openai-adapter/src/Chat/OpenaiChatAdapter.php
@@ -103,7 +103,9 @@ final readonly class OpenaiChatAdapter implements AIChatAdapterInterface, Suppor
                             'type' => $tool->type->value,
                             'function' => [
                                 'name' => $tool->name,
-                                'arguments' => (string) \json_encode($tool->arguments),
+                                // a tool call without arguments has to send an empty object, an
+                                // empty array would be encoded as []
+                                'arguments' => (string) \json_encode([] !== $tool->arguments ? $tool->arguments : new \stdClass()),
                             ],
                         ],
                         $part->toolCalls,


### PR DESCRIPTION
A tool call without arguments is repeated with an empty php array, which is encoded as `[]` instead of `{}` and rejected by Anthropic with `messages.N.content.0.tool_use.input: Input should be an object`, so every conversation that replays a parameterless tool call fails. Confirmed in production on 30.7. — a `list_webcams` tool call sent back by the client made the whole follow-up request fail.

This is the sibling of #155 and #156: those fixed the `properties` of the tool **schema**, this is the `input` of the tool **call** itself, one layer over.

- `anthropic-adapter` sends an empty object as `input` — the confirmed rejection
- `openai-adapter`, `mistral-adapter`, `fireworksai-adapter` and the shared `ToolCallsPart` send `"{}"` instead of `"[]"` as `arguments`
- the parameter validation of the `anthropic` client accepts the empty object, and the request side of the tool use message type is separated from the response side, which is always decoded into an array

The Google Gemini adapter is not affected: its client omits `args` of a function call entirely when they are empty.

### Tests

- `ToolCallsPartTest::testEnhanceMessageWithoutArguments` covers the shared serialization the OpenAI family mirrors
- `AnthropicChatAdapterTest::testHandleRequestWithToolCallsPartWithoutArguments` captures the payload and asserts `"input":{}` — the mock response matcher compares with `!==`, so two empty objects would never match
- the api compatibility job of the platform is extended to actually call a parameterless tool in the roundtrip turn, which covers the OpenAI family against the live apis

`composer test` and `composer lint` pass for `anthropic`, `anthropic-adapter`, `chat`, `openai-adapter`, `mistral-adapter` and `fireworksai-adapter`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed tool calls without arguments being sent as empty arrays instead of empty objects.
  - Improved compatibility with AI provider APIs that reject empty arrays for tool-call inputs.
  - Preserved existing serialization behavior for tool calls that include arguments.

- **Tests**
  - Added regression coverage to verify correct empty-object formatting across supported chat integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->